### PR TITLE
ofxImageEffect.h - Desired Premult

### DIFF
--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -4,7 +4,7 @@
 /*
 Software License :
 
-Copyright (c) 2003-2019, The Open Effects Association Ltd. All rights reserved.
+Copyright (c) 2003-2020, The Open Effects Association Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -980,6 +980,7 @@ This is the actual value of the component depth, before any mapping by clip pref
       - kOfxImageUnPreMultiplied - the image is unpremultiplied
 
 See the documentation on clip preferences for more details on how this is used with the ::kOfxImageEffectActionGetClipPreferences action.
+version 1.5 and over:  See kOfxImageEffectHostDesiredPremult and how it interacts with this property.
 */
 #define kOfxImageEffectPropPreMultiplication "OfxImageEffectPropPreMultiplication"
 
@@ -993,17 +994,20 @@ See the documentation on clip preferences for more details on how this is used w
 #define kOfxImageUnPreMultiplied "OfxImageAlphaUnPremultiplied"
 
 /** @brief Indicates whether an effect should premultiply or not on output.
-This provides clarification for generators or effect where input is kOfxImageOpaque.
+Added in version 1.5: This provides clarification for generators or effect where input is kOfxImageOpaque.
 
 - Type - string X 1
-- Property Set - a plugin  instance (read only)
-- Default - 0
+- Property Set - a plugin  instance (read only). Ideally this information should already be available at parameter creation stage.
 Valid Values - This must be one of
 
 - kOfxImagePreMultiplied   - the image is premultiplied by its alpha
 - kOfxImageUnPreMultiplied - the image is unpremultiplied
 
-This Property defines an host level policy.
+This Property defines an host level policy. It is for practical purposes considered global in the scope of a Project.
+
+Recommended Interpretation: If an host adds support for OfxImageEffectHostDesiredPremult, the host should set on the output the same value on output clip kOfxImageEffectPropPreMultiplication preference 
+::kOfxImageEffectActionGetClipPreference. A plugin that does not touch the alpha channel can reset output to kOfxImageOpaque when input was that or the effect fills completely the alpha channel. 
+This guarantees that the host knows that the kOfxImageOpaque property is reliable.
 */
 
 #define kOfxImageEffectHostDesiredPremult "OfxImageEffectHostDesiredPremult"

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -4,7 +4,7 @@
 /*
 Software License :
 
-Copyright (c) 2003-2015, The Open Effects Association Ltd. All rights reserved.
+Copyright (c) 2003-2019, The Open Effects Association Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -992,6 +992,21 @@ See the documentation on clip preferences for more details on how this is used w
 /** Used to flag an image as unpremultiplied */
 #define kOfxImageUnPreMultiplied "OfxImageAlphaUnPremultiplied"
 
+/** @brief Indicates whether an effect should premultiply or not on output.
+This provides clarification for generators or effect where input is kOfxImageOpaque.
+
+- Type - string X 1
+- Property Set - a plugin  instance (read only)
+- Default - 0
+Valid Values - This must be one of
+
+- kOfxImagePreMultiplied   - the image is premultiplied by its alpha
+- kOfxImageUnPreMultiplied - the image is unpremultiplied
+
+This Property defines an host level policy.
+*/
+
+#define kOfxImageEffectHostDesiredPremult "OfxImageEffectHostDesiredPremult"
 
 /** @brief Indicates the bit depths support by a plug-in or host
     

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -994,20 +994,27 @@ version 1.5 and over:  See kOfxImageEffectHostDesiredPremult and how it interact
 #define kOfxImageUnPreMultiplied "OfxImageAlphaUnPremultiplied"
 
 /** @brief Indicates whether an effect should premultiply or not on output.
-Added in version 1.5: This provides clarification for generators or effect where input is kOfxImageOpaque.
+Added in version 1.5: This provides clarification for generators or effect when input is kOfxImageOpaque.
 
 - Type - string X 1
-- Property Set - a plugin  instance (read only). Ideally this information should already be available at parameter creation stage.
-Valid Values - This must be one of
+- Property Set - a plugin  instance (read only). 
 
+Valid Values - This must be one of
 - kOfxImagePreMultiplied   - the image is premultiplied by its alpha
 - kOfxImageUnPreMultiplied - the image is unpremultiplied
 
-This Property defines an host level policy. It is for practical purposes considered global in the scope of a Project.
+This Property defines an host level policy. We assume an host is either one of the two options.
+This information should already be available at parameter creation stage.
 
-Recommended Interpretation: If an host adds support for OfxImageEffectHostDesiredPremult, the host should set on the output the same value on output clip kOfxImageEffectPropPreMultiplication preference 
-::kOfxImageEffectActionGetClipPreference. A plugin that does not touch the alpha channel can reset output to kOfxImageOpaque when input was that or the effect fills completely the alpha channel. 
-This guarantees that the host knows that the kOfxImageOpaque property is reliable.
+@returns
+- ::kOfxStatOK			- the property set was found and returned
+- ::kOfxStatErrUnsupported- if the property is not supported
+
+Expected Interpretation: If an host adds support for the OfxImageEffectHostDesiredPremult property, that host should set the kOfxImageEffectPropPreMultiplication property on
+the output of ::kOfxImageEffectActionGetClipPreference to the desired premultiplication value. 
+Then a plugin that does not touch the alpha channel can reset the clip preference output to kOfxImageOpaque when the input clip was set to kOfxImageOpaque or the effect fills completely opaque the alpha channel. 
+This guarantees that the host knows that the kOfxImageOpaque property is reliable outside of the context of a direct connection to source footage. 
+This should be queryable during parameter creation for effects that currently have a parameter for that so they can hide it or remove it when this property is supported.
 */
 
 #define kOfxImageEffectHostDesiredPremult "OfxImageEffectHostDesiredPremult"


### PR DESCRIPTION
This Property defines an host level policy. So effects receiving an ImageOpaque and Generator know to be Premult or Straight if they don't generate a full Alpha. See Standard Change issue #66.

 