### PR TITLE
Remove deprecated exception specifications.

### DIFF
--- a/HostSupport/include/ofxhClip.h
+++ b/HostSupport/include/ofxhClip.h
@@ -116,31 +116,31 @@ namespace OFX {
         bool isOutput() const {return  _isOutput;}
 
         /// notify override properties
-        virtual void notify(const std::string &name, bool isSingle, int indexOrN)  OFX_EXCEPTION_SPEC;
+        virtual void notify(const std::string &name, bool isSingle, int indexOrN);
         
         /// get hook override
-        virtual void reset(const std::string &name) OFX_EXCEPTION_SPEC;
+        virtual void reset(const std::string &name);
 
         // get the virtuals for viewport size, pixel scale, background colour
-        virtual double getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC;
+        virtual double getDoubleProperty(const std::string &name, int index) const;
 
         // get the virtuals for viewport size, pixel scale, background colour
-        virtual void getDoublePropertyN(const std::string &name, double *values, int count) const  OFX_EXCEPTION_SPEC;
+        virtual void getDoublePropertyN(const std::string &name, double *values, int count) const;
 
         // get the virtuals for viewport size, pixel scale, background colour
-        virtual int getIntProperty(const std::string &name, int index) const  OFX_EXCEPTION_SPEC;
+        virtual int getIntProperty(const std::string &name, int index) const;
 
         // get the virtuals for viewport size, pixel scale, background colour
-        virtual void getIntPropertyN(const std::string &name, int *values, int count) const  OFX_EXCEPTION_SPEC;
+        virtual void getIntPropertyN(const std::string &name, int *values, int count) const;
 
         // get the virtuals for viewport size, pixel scale, background colour
-        virtual const std::string &getStringProperty(const std::string &name, int index) const  OFX_EXCEPTION_SPEC;
+        virtual const std::string &getStringProperty(const std::string &name, int index) const;
                              
         // fetch  multiple values in a multi-dimension property
-        virtual void getStringPropertyN(const std::string &name, const char** values, int count) const OFX_EXCEPTION_SPEC;
+        virtual void getStringPropertyN(const std::string &name, const char** values, int count) const;
 
         // get hook virtuals
-        virtual int  getDimension(const std::string &name) const OFX_EXCEPTION_SPEC;
+        virtual int  getDimension(const std::string &name) const;
 
         // instance changed action
         OfxStatus instanceChangedAction(const std::string &why,

--- a/HostSupport/include/ofxhImageEffect.h
+++ b/HostSupport/include/ofxhImageEffect.h
@@ -408,19 +408,19 @@ namespace OFX {
         int upperGetDimension(const std::string &name);
 
         /// overridden from Property::Notify
-        virtual void notify(const std::string &name, bool singleValue, int indexOrN) OFX_EXCEPTION_SPEC;
+        virtual void notify(const std::string &name, bool singleValue, int indexOrN);
 
         /// overridden from gethook,  get the virutals for viewport size, pixel scale, background colour
-        virtual double getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC;
+        virtual double getDoubleProperty(const std::string &name, int index) const;
 
         /// overridden from gethook,  get the virutals for viewport size, pixel scale, background colour
-        virtual void getDoublePropertyN(const std::string &name, double *values, int count) const OFX_EXCEPTION_SPEC;
+        virtual void getDoublePropertyN(const std::string &name, double *values, int count) const;
         
         /// overridden from gethook, don't know what to do
-        virtual void reset(const std::string &name) OFX_EXCEPTION_SPEC;
+        virtual void reset(const std::string &name);
 
         //// overridden from gethook
-        virtual int getDimension(const std::string &name)  const OFX_EXCEPTION_SPEC;
+        virtual int getDimension(const std::string &name)  const;
 
         //
         // live parameters

--- a/HostSupport/include/ofxhInteract.h
+++ b/HostSupport/include/ofxhInteract.h
@@ -143,16 +143,16 @@ namespace OFX {
         virtual void getSlaveToParam(std::vector<std::string>& params) const;
 
         // do nothing
-        virtual int  getDimension(const std::string &name) const OFX_EXCEPTION_SPEC;
+        virtual int  getDimension(const std::string &name) const;
         
         // don't know what to do
-        virtual void reset(const std::string &name) OFX_EXCEPTION_SPEC;
+        virtual void reset(const std::string &name);
 
         /// the gethook virutals for  pixel scale, background colour
-        virtual double getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC;
+        virtual double getDoubleProperty(const std::string &name, int index) const;
 
         /// for pixel scale and background colour
-        virtual void getDoublePropertyN(const std::string &name, double *first, int n) const OFX_EXCEPTION_SPEC;
+        virtual void getDoublePropertyN(const std::string &name, double *first, int n) const;
 
         /// call create instance
         virtual OfxStatus createInstanceAction();

--- a/HostSupport/include/ofxhParam.h
+++ b/HostSupport/include/ofxhParam.h
@@ -231,7 +231,7 @@ namespace OFX {
         virtual OfxStatus integrateV(OfxTime time1, OfxTime time2, va_list arg);
 
         /// overridden from Property::NotifyHook
-        virtual void notify(const std::string &name, bool single, int num) OFX_EXCEPTION_SPEC;
+        virtual void notify(const std::string &name, bool single, int num);
       };
 
       class KeyframeParam {
@@ -323,7 +323,7 @@ namespace OFX {
         virtual OfxStatus setV(OfxTime time, va_list arg);
 
         /// overridden from Instance
-        virtual void notify(const std::string &name, bool single, int num) OFX_EXCEPTION_SPEC;
+        virtual void notify(const std::string &name, bool single, int num);
       };
 
       class DoubleInstance : public Instance, public KeyframeParam {

--- a/HostSupport/include/ofxhPropertySuite.h
+++ b/HostSupport/include/ofxhPropertySuite.h
@@ -10,12 +10,6 @@
 #include <algorithm>
 #include <sstream>
 
-#ifndef WINDOWS
-#define OFX_EXCEPTION_SPEC throw (OFX::Host::Property::Exception)
-#else
-#define OFX_EXCEPTION_SPEC 
-#endif
-
 namespace OFX {
   namespace Host {
     namespace Property {
@@ -126,41 +120,41 @@ namespace OFX {
 
         /// We specialise this to do some magic so that it calls get string/int/double/pointer appropriately
         /// this is what is called by the propertytemplate code to fetch values out of a hook.
-        template<class T> typename T::ReturnType getProperty(const std::string &name, int index=0) const OFX_EXCEPTION_SPEC;
+        template<class T> typename T::ReturnType getProperty(const std::string &name, int index=0) const;
 
         /// We specialise this to do some magic so that it calls get int/double/pointer appropriately
         /// this is what is called by the propertytemplate code to fetch values out of a hook.
-        template<class T> void getPropertyN(const std::string &name, typename T::APIType *values, int count) const OFX_EXCEPTION_SPEC;
+        template<class T> void getPropertyN(const std::string &name, typename T::APIType *values, int count) const;
 
         /// override this to fetch a single value at the given index.
-        virtual const std::string& getStringProperty(const std::string &name, int index = 0) const OFX_EXCEPTION_SPEC;
+        virtual const std::string& getStringProperty(const std::string &name, int index = 0) const;
           
         /// override this to fetch a multiple values in a multi-dimension property
-        virtual void getStringPropertyN(const std::string &name, const char** values, int count) const OFX_EXCEPTION_SPEC;
+        virtual void getStringPropertyN(const std::string &name, const char** values, int count) const;
 
         /// override this to fetch a single value at the given index.
-        virtual int getIntProperty(const std::string &name, int index = 0) const OFX_EXCEPTION_SPEC;
+        virtual int getIntProperty(const std::string &name, int index = 0) const;
 
         /// override this to fetch a multiple values in a multi-dimension property
-        virtual void getIntPropertyN(const std::string &name, int *values, int count) const OFX_EXCEPTION_SPEC;
+        virtual void getIntPropertyN(const std::string &name, int *values, int count) const;
 
         /// override this to fetch a single value at the given index.
-        virtual double getDoubleProperty(const std::string &name, int index = 0) const OFX_EXCEPTION_SPEC;
+        virtual double getDoubleProperty(const std::string &name, int index = 0) const;
 
         /// override this to fetch a multiple values in a multi-dimension property
-        virtual void getDoublePropertyN(const std::string &name, double *values, int count) const OFX_EXCEPTION_SPEC;
+        virtual void getDoublePropertyN(const std::string &name, double *values, int count) const;
 
         /// override this to fetch a single value at the given index.
-        virtual void *getPointerProperty(const std::string &name, int index = 0) const OFX_EXCEPTION_SPEC;
+        virtual void *getPointerProperty(const std::string &name, int index = 0) const;
         
         /// override this to fetch a multiple values in a multi-dimension property
-        virtual void getPointerPropertyN(const std::string &name, void **values, int count) const OFX_EXCEPTION_SPEC;
+        virtual void getPointerPropertyN(const std::string &name, void **values, int count) const;
 
         /// override this to fetch the dimension size.
-        virtual int getDimension(const std::string &name) const OFX_EXCEPTION_SPEC;
+        virtual int getDimension(const std::string &name) const;
 
         /// override this to handle a reset(). 
-        virtual void reset(const std::string &name) OFX_EXCEPTION_SPEC;
+        virtual void reset(const std::string &name);
       };
 
       /// Sits on a property and is called when the local property is being set.
@@ -178,7 +172,7 @@ namespace OFX {
         /// \arg name is the name of the property just set
         /// \arg singleValue is whether setProperty on a single index was call, otherwise N properties were set
         /// \arg indexOrN is the index if single value is true, or the count if singleValue is false
-        virtual void notify(const std::string &name, bool singleValue, int indexOrN) OFX_EXCEPTION_SPEC = 0;
+        virtual void notify(const std::string &name, bool singleValue, int indexOrN) = 0;
       };
 
       /// base class for all properties
@@ -309,34 +303,34 @@ namespace OFX {
         }
 
         // get multiple values
-        void getValueN(APIType *value, int count) const OFX_EXCEPTION_SPEC;
+        void getValueN(APIType *value, int count) const;
 
 #ifdef WINDOWS
 #pragma warning( disable : 4181 )	
 #endif		
         /// get one value
-        const ReturnType getValue(int index=0) const OFX_EXCEPTION_SPEC;
+        const ReturnType getValue(int index=0) const;
 
         /// get one value, without going through the getHook
-        const ReturnType getValueRaw(int index=0) const OFX_EXCEPTION_SPEC;
+        const ReturnType getValueRaw(int index=0) const;
 
 #ifdef WINDOWS
 #pragma warning( default : 4181 )	
 #endif				
         // get multiple values, without going through the getHook
-        void getValueNRaw(APIType *value, int count) const OFX_EXCEPTION_SPEC;
+        void getValueNRaw(APIType *value, int count) const;
 
         /// set one value
-        void setValue(const Type &value, int index=0) OFX_EXCEPTION_SPEC;
+        void setValue(const Type &value, int index=0);
 
         /// set multiple values
-        void setValueN(const APIType *value, int count) OFX_EXCEPTION_SPEC;
+        void setValueN(const APIType *value, int count);
 
         /// reset 
-        void reset() OFX_EXCEPTION_SPEC;
+        void reset();
         
         /// get the size of the vector
-        int getDimension() const OFX_EXCEPTION_SPEC;
+        int getDimension() const;
         
         /// return the value as a string
         inline std::string getStringValue(int idx) {

--- a/HostSupport/src/ofxhClip.cpp
+++ b/HostSupport/src/ofxhClip.cpp
@@ -214,7 +214,7 @@ namespace OFX {
       }
 
       // do nothing
-      int ClipInstance::getDimension(const std::string &name) const OFX_EXCEPTION_SPEC 
+      int ClipInstance::getDimension(const std::string &name) const 
       {
         if(name == kOfxImageEffectPropUnmappedFrameRange || name == kOfxImageEffectPropFrameRange)
           return 2;
@@ -222,7 +222,7 @@ namespace OFX {
       }
 
       // don't know what to do
-      void ClipInstance::reset(const std::string &/*name*/) OFX_EXCEPTION_SPEC {
+      void ClipInstance::reset(const std::string &/*name*/) {
         //printf("failing in %s\n", __PRETTY_FUNCTION__);
         throw Property::Exception(kOfxStatErrMissingHostFeature);
       }
@@ -240,7 +240,7 @@ namespace OFX {
       }
        
       // get the virutals for viewport size, pixel scale, background colour
-      void ClipInstance::getDoublePropertyN(const std::string &name, double *values, int n) const OFX_EXCEPTION_SPEC
+      void ClipInstance::getDoublePropertyN(const std::string &name, double *values, int n) const
       {
         if(name==kOfxImagePropPixelAspectRatio){
           if(n>1) throw Property::Exception(kOfxStatErrValue);
@@ -267,7 +267,7 @@ namespace OFX {
       }
 
       // get the virutals for viewport size, pixel scale, background colour
-      double ClipInstance::getDoubleProperty(const std::string &name, int n) const OFX_EXCEPTION_SPEC
+      double ClipInstance::getDoubleProperty(const std::string &name, int n) const
       {
         if(name==kOfxImagePropPixelAspectRatio){
           if(n!=0) throw Property::Exception(kOfxStatErrValue);
@@ -298,7 +298,7 @@ namespace OFX {
       }
 
       // get the virutals for viewport size, pixel scale, background colour
-      int ClipInstance::getIntProperty(const std::string &name, int n) const OFX_EXCEPTION_SPEC
+      int ClipInstance::getIntProperty(const std::string &name, int n) const
       {
         if(n!=0) throw Property::Exception(kOfxStatErrValue);
         if(name==kOfxImageClipPropConnected){
@@ -312,14 +312,14 @@ namespace OFX {
       }
 
       // get the virutals for viewport size, pixel scale, background colour
-      void ClipInstance::getIntPropertyN(const std::string &name, int *values, int n) const OFX_EXCEPTION_SPEC
+      void ClipInstance::getIntPropertyN(const std::string &name, int *values, int n) const
       {
         if(n!=0) throw Property::Exception(kOfxStatErrValue);
         *values = getIntProperty(name, 0);
       }
 
       // get the virutals for viewport size, pixel scale, background colour
-      const std::string &ClipInstance::getStringProperty(const std::string &name, int n) const OFX_EXCEPTION_SPEC
+      const std::string &ClipInstance::getStringProperty(const std::string &name, int n) const
       {
         if(n!=0) throw Property::Exception(kOfxStatErrValue);
         if(name==kOfxImageEffectPropPixelDepth){
@@ -345,7 +345,7 @@ namespace OFX {
       }
        
       // fetch  multiple values in a multi-dimension property
-      void ClipInstance::getStringPropertyN(const std::string &name, const char** values, int count) const OFX_EXCEPTION_SPEC
+      void ClipInstance::getStringPropertyN(const std::string &name, const char** values, int count) const
       {
           if (count == 0) {
               return;
@@ -374,7 +374,7 @@ namespace OFX {
       }
 
       // notify override properties
-      void ClipInstance::notify(const std::string &/*name*/, bool /*isSingle*/, int /*indexOrN*/)  OFX_EXCEPTION_SPEC
+      void ClipInstance::notify(const std::string &/*name*/, bool /*isSingle*/, int /*indexOrN*/) 
       {
       }
 

--- a/HostSupport/src/ofxhImageEffect.cpp
+++ b/HostSupport/src/ofxhImageEffect.cpp
@@ -456,7 +456,7 @@ namespace OFX {
       }
 
       // do nothing
-      int Instance::getDimension(const std::string &name) const OFX_EXCEPTION_SPEC {
+      int Instance::getDimension(const std::string &name) const {
         printf("failing in %s with name=%s\n", __PRETTY_FUNCTION__, name.c_str());
         throw Property::Exception(kOfxStatErrMissingHostFeature);
       }
@@ -465,19 +465,19 @@ namespace OFX {
         return _properties.getDimension(name);
       }
 
-      void Instance::notify(const std::string &/*name*/, bool /*singleValue*/, int /*indexOrN*/) OFX_EXCEPTION_SPEC
+      void Instance::notify(const std::string &/*name*/, bool /*singleValue*/, int /*indexOrN*/)
       { 
         printf("failing in %s\n", __PRETTY_FUNCTION__);
       }
 
       // don't know what to do
-      void Instance::reset(const std::string &/*name*/) OFX_EXCEPTION_SPEC {
+      void Instance::reset(const std::string &/*name*/) {
         printf("failing in %s\n", __PRETTY_FUNCTION__);
         throw Property::Exception(kOfxStatErrMissingHostFeature);
       }
 
       // get the virutals for viewport size, pixel scale, background colour
-      double Instance::getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC
+      double Instance::getDoubleProperty(const std::string &name, int index) const
       {
         if(name==kOfxImageEffectPropProjectSize){
           if(index>=2) throw Property::Exception(kOfxStatErrBadIndex);
@@ -513,7 +513,7 @@ namespace OFX {
           throw Property::Exception(kOfxStatErrUnknown);        
       }
 
-      void Instance::getDoublePropertyN(const std::string &name, double* first, int n) const OFX_EXCEPTION_SPEC
+      void Instance::getDoublePropertyN(const std::string &name, double* first, int n) const
       {
         if(name==kOfxImageEffectPropProjectSize){
           if(n>2) throw Property::Exception(kOfxStatErrBadIndex);
@@ -2175,7 +2175,7 @@ namespace OFX {
           *memoryHandle = NULL;
           return kOfxStatErrMemory;
         }
-        } catch (std::bad_alloc) {
+        } catch (std::bad_alloc&) {
           *memoryHandle = NULL;
           return kOfxStatErrMemory;
         } catch (...) {

--- a/HostSupport/src/ofxhInteract.cpp
+++ b/HostSupport/src/ofxhInteract.cpp
@@ -149,7 +149,7 @@ namespace OFX {
       }
       
       // do nothing
-      int Instance::getDimension(const std::string &name) const OFX_EXCEPTION_SPEC
+      int Instance::getDimension(const std::string &name) const
       {
         if(name == kOfxInteractPropPixelScale){
           return 2;
@@ -171,12 +171,12 @@ namespace OFX {
       }
         
       // do nothing function
-      void Instance::reset(const std::string &/*name*/) OFX_EXCEPTION_SPEC
+      void Instance::reset(const std::string &/*name*/)
       {
         // no-op
       }
 
-      double Instance::getDoubleProperty(const std::string &name, int index) const OFX_EXCEPTION_SPEC
+      double Instance::getDoubleProperty(const std::string &name, int index) const
       {   
         if(name == kOfxInteractPropPixelScale){
           if(index>=2) throw Property::Exception(kOfxStatErrBadIndex);
@@ -210,7 +210,7 @@ namespace OFX {
           throw Property::Exception(kOfxStatErrUnknown);
       }
 
-      void Instance::getDoublePropertyN(const std::string &name, double *first, int n) const OFX_EXCEPTION_SPEC
+      void Instance::getDoublePropertyN(const std::string &name, double *first, int n) const
       {
         if(name == kOfxInteractPropPixelScale){
           if(n>2) throw Property::Exception(kOfxStatErrBadIndex);

--- a/HostSupport/src/ofxhParam.cpp
+++ b/HostSupport/src/ofxhParam.cpp
@@ -624,7 +624,7 @@ namespace OFX {
       }
 
       /// overridden from Property::NotifyHook
-      void Instance::notify(const std::string &name, bool /*single*/, int /*num*/) OFX_EXCEPTION_SPEC
+      void Instance::notify(const std::string &name, bool /*single*/, int /*num*/)
       {
         if (name == kOfxPropLabel) {
           setLabel();
@@ -783,7 +783,7 @@ namespace OFX {
       }
       
       /// overridden from Instance
-      void ChoiceInstance::notify(const std::string &name, bool single, int num) OFX_EXCEPTION_SPEC
+      void ChoiceInstance::notify(const std::string &name, bool single, int num)
       {
         Instance::notify(name, single, num);
         if (name == kOfxParamPropChoiceOption) {

--- a/HostSupport/src/ofxhPropertySuite.cpp
+++ b/HostSupport/src/ofxhPropertySuite.cpp
@@ -25,56 +25,56 @@ namespace OFX {
       const char *gTypeNames[] = {"int", "double", "string", "pointer" };
 
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> int GetHook::getProperty<IntValue>(const std::string &name, int index) const OFX_EXCEPTION_SPEC
+      template<> int GetHook::getProperty<IntValue>(const std::string &name, int index) const
       {
         return getIntProperty(name, index);
       }
 
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> double GetHook::getProperty<DoubleValue>(const std::string &name, int index) const OFX_EXCEPTION_SPEC
+      template<> double GetHook::getProperty<DoubleValue>(const std::string &name, int index) const
       {
         return getDoubleProperty(name, index);
       }
       
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> void *GetHook::getProperty<PointerValue>(const std::string &name, int index) const OFX_EXCEPTION_SPEC
+      template<> void *GetHook::getProperty<PointerValue>(const std::string &name, int index) const
       {
         return getPointerProperty(name, index);
       }
 
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> const std::string &GetHook::getProperty<StringValue>(const std::string &name, int index) const OFX_EXCEPTION_SPEC
+      template<> const std::string &GetHook::getProperty<StringValue>(const std::string &name, int index) const
       {
         return getStringProperty(name, index);
       }
             
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> void GetHook::getPropertyN<IntValue>(const std::string &name, int *values, int count) const OFX_EXCEPTION_SPEC
+      template<> void GetHook::getPropertyN<IntValue>(const std::string &name, int *values, int count) const
       {
         getIntPropertyN(name, values, count);
       }
 
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> void GetHook::getPropertyN<DoubleValue>(const std::string &name, double *values, int count) const OFX_EXCEPTION_SPEC
+      template<> void GetHook::getPropertyN<DoubleValue>(const std::string &name, double *values, int count) const
       {
         getDoublePropertyN(name, values, count);
       }
       
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> void GetHook::getPropertyN<PointerValue>(const std::string &name, void **values, int count) const OFX_EXCEPTION_SPEC
+      template<> void GetHook::getPropertyN<PointerValue>(const std::string &name, void **values, int count) const
       {
         getPointerPropertyN(name, values, count);
       }
         
       /// this does some magic so that it calls get string/int/double/pointer appropriately
-      template<> void GetHook::getPropertyN<StringValue>(const std::string &name, const char **values, int count) const OFX_EXCEPTION_SPEC
+      template<> void GetHook::getPropertyN<StringValue>(const std::string &name, const char **values, int count) const
       {
         getStringPropertyN(name, values, count);
       }
 
 
       /// override this to get a single value at the given index.
-      const std::string &GetHook::getStringProperty(const std::string &/*name*/, int /*index*/) const OFX_EXCEPTION_SPEC
+      const std::string &GetHook::getStringProperty(const std::string &/*name*/, int /*index*/) const
       {        
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getStringProperty!!!! " << std::endl;
@@ -83,7 +83,7 @@ namespace OFX {
       }
        
        /// override this function to optimize multiple-string properties fetching
-      void GetHook::getStringPropertyN(const std::string &name, const char** values, int count) const OFX_EXCEPTION_SPEC
+      void GetHook::getStringPropertyN(const std::string &name, const char** values, int count) const
       {
         for (int i = 0; i < count; ++i) {
           values[i] = getStringProperty(name, i).c_str();
@@ -91,7 +91,7 @@ namespace OFX {
       }
       
       /// override this to fetch a single value at the given index.
-      int GetHook::getIntProperty(const std::string &/*name*/, int /*index*/) const OFX_EXCEPTION_SPEC
+      int GetHook::getIntProperty(const std::string &/*name*/, int /*index*/) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getIntProperty!!!! " << std::endl;
@@ -100,7 +100,7 @@ namespace OFX {
       }
       
       /// override this to fetch a single value at the given index.
-      double GetHook::getDoubleProperty(const std::string &/*name*/, int /*index*/) const OFX_EXCEPTION_SPEC
+      double GetHook::getDoubleProperty(const std::string &/*name*/, int /*index*/) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getDoubleProperty!!!! " << std::endl;
@@ -109,7 +109,7 @@ namespace OFX {
       }
       
       /// override this to fetch a single value at the given index.
-      void *GetHook::getPointerProperty(const std::string &/*name*/, int /*index*/) const OFX_EXCEPTION_SPEC
+      void *GetHook::getPointerProperty(const std::string &/*name*/, int /*index*/) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getPointerProperty!!!! " << std::endl;
@@ -118,7 +118,7 @@ namespace OFX {
       }
       
       /// override this to fetch a multiple values in a multi-dimension property
-      void GetHook::getDoublePropertyN(const std::string &/*name*/, double *values, int count) const OFX_EXCEPTION_SPEC
+      void GetHook::getDoublePropertyN(const std::string &/*name*/, double *values, int count) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getDoublePropertyN!!!! " << std::endl;
@@ -127,7 +127,7 @@ namespace OFX {
       }
 
       /// override this to fetch a multiple values in a multi-dimension property
-      void GetHook::getIntPropertyN(const std::string &/*name*/, int *values, int count) const OFX_EXCEPTION_SPEC
+      void GetHook::getIntPropertyN(const std::string &/*name*/, int *values, int count) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getIntPropertyN!!!! " << std::endl;
@@ -136,7 +136,7 @@ namespace OFX {
       }
 
       /// override this to fetch a multiple values in a multi-dimension property
-      void GetHook::getPointerPropertyN(const std::string &/*name*/, void **values, int count) const OFX_EXCEPTION_SPEC
+      void GetHook::getPointerPropertyN(const std::string &/*name*/, void **values, int count) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getPointerPropertyN!!!! " << std::endl;
@@ -146,7 +146,7 @@ namespace OFX {
 
 
       /// override this to fetch the dimension size.
-      int GetHook::getDimension(const std::string &/*name*/) const OFX_EXCEPTION_SPEC
+      int GetHook::getDimension(const std::string &/*name*/) const
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::getDimension!!!! " << std::endl;
@@ -155,7 +155,7 @@ namespace OFX {
       }
       
       /// override this to handle a reset(). 
-      void GetHook::reset(const std::string &/*name*/) OFX_EXCEPTION_SPEC
+      void GetHook::reset(const std::string &/*name*/)
       {
 #       ifdef OFX_DEBUG_PROPERTIES
         std::cout << "OFX: Calling un-overriden GetHook::reset!!!! " << std::endl;
@@ -229,7 +229,7 @@ namespace OFX {
 #endif
       /// get one value
       template<class T> 
-      const typename T::ReturnType PropertyTemplate<T>::getValue(int index) const OFX_EXCEPTION_SPEC 
+      const typename T::ReturnType PropertyTemplate<T>::getValue(int index) const 
       {
         if (_getHook) {
           return _getHook->getProperty<T>(_name, index);
@@ -243,7 +243,7 @@ namespace OFX {
 #endif
       // get multiple values
       template<class T> 
-      void PropertyTemplate<T>::getValueN(typename T::APIType *values, int count) const OFX_EXCEPTION_SPEC {
+      void PropertyTemplate<T>::getValueN(typename T::APIType *values, int count) const {
         if (_getHook) {
           _getHook->getPropertyN<T>(_name, values, count);
         } 
@@ -257,7 +257,7 @@ namespace OFX {
 #endif
       /// get one value, without going through the getHook
       template<class T> 
-      const typename T::ReturnType PropertyTemplate<T>::getValueRaw(int index) const OFX_EXCEPTION_SPEC
+      const typename T::ReturnType PropertyTemplate<T>::getValueRaw(int index) const
       {
         if (index < 0 || ((size_t)index >= _value.size())) {
           throw Exception(kOfxStatErrBadIndex);
@@ -269,7 +269,7 @@ namespace OFX {
 #endif      
       // get multiple values, without going through the getHook
       template<class T> 
-      void PropertyTemplate<T>::getValueNRaw(APIType *value, int count) const OFX_EXCEPTION_SPEC
+      void PropertyTemplate<T>::getValueNRaw(APIType *value, int count) const
       {
         size_t size = count;
         if (size > _value.size()) {
@@ -282,7 +282,7 @@ namespace OFX {
       }
 
       /// set one value
-      template<class T> void PropertyTemplate<T>::setValue(const typename T::Type &value, int index) OFX_EXCEPTION_SPEC 
+      template<class T> void PropertyTemplate<T>::setValue(const typename T::Type &value, int index) 
       {
         if (index < 0 || ((size_t)index > _value.size() && _dimension)) {
           throw Exception(kOfxStatErrBadIndex);
@@ -297,7 +297,7 @@ namespace OFX {
       }
 
       /// set multiple values
-      template<class T> void PropertyTemplate<T>::setValueN(const typename T::APIType *value, int count) OFX_EXCEPTION_SPEC
+      template<class T> void PropertyTemplate<T>::setValueN(const typename T::APIType *value, int count)
       {
         if (_dimension && ((size_t)count > _value.size())) {
           throw Exception(kOfxStatErrBadIndex);              
@@ -313,7 +313,7 @@ namespace OFX {
       }
         
       /// get the dimension of the property
-      template <class T> int PropertyTemplate<T>::getDimension() const OFX_EXCEPTION_SPEC {
+      template <class T> int PropertyTemplate<T>::getDimension() const {
         if (_dimension != 0) {
           return _dimension;
         } 
@@ -328,7 +328,7 @@ namespace OFX {
         }
       }
 
-      template <class T> void PropertyTemplate<T>::reset() OFX_EXCEPTION_SPEC 
+      template <class T> void PropertyTemplate<T>::reset() 
       {
         if (_getHook) {
           _getHook->reset(_name);

--- a/Support/Library/ofxsCore.cpp
+++ b/Support/Library/ofxsCore.cpp
@@ -13,7 +13,7 @@
 
 namespace OFX {
   /** @brief Throws an @ref OFX::Exception depending on the status flag passed in */
-  void throwSuiteStatusException(OfxStatus stat) throw(OFX::Exception::Suite, std::bad_alloc)
+  void throwSuiteStatusException(OfxStatus stat)
   {
     switch (stat) 
     {
@@ -43,7 +43,7 @@ namespace OFX {
     }
   }
 
-  void throwHostMissingSuiteException(std::string name) throw(OFX::Exception::Suite)
+  void throwHostMissingSuiteException(std::string name)
   {
 #  ifdef DEBUG
     std::cout << "Threw suite exception! Host missing '" << name << "' suite." << std::endl;
@@ -90,7 +90,7 @@ namespace OFX {
   /** @brief namespace for memory allocation that is done via wrapping the ofx memory suite */
   namespace Memory {
     /** @brief allocate n bytes, returns a pointer to it */
-    void *allocate(size_t nBytes, ImageEffect *effect) throw(std::bad_alloc)
+    void *allocate(size_t nBytes, ImageEffect *effect)
     {
       void *data = 0;
       OfxStatus stat = OFX::Private::gMemorySuite->memoryAlloc((void *)(effect ? effect->getHandle() : 0), nBytes, &data);

--- a/Support/Library/ofxsImageEffect.cpp
+++ b/Support/Library/ofxsImageEffect.cpp
@@ -133,7 +133,7 @@ namespace OFX {
   };
 
   /** @brief map a std::string to a context */
-  ContextEnum mapToContextEnum(const std::string &s) throw(std::invalid_argument)
+  ContextEnum mapToContextEnum(const std::string &s)
   {
     if(s == kOfxImageEffectContextGenerator) return eContextGenerator;
     if(s == kOfxImageEffectContextFilter) return eContextFilter;
@@ -145,7 +145,7 @@ namespace OFX {
     throw std::invalid_argument(s);
   }
 
-  const char* mapContextEnumToStr(ContextEnum context) throw(std::invalid_argument)
+  const char* mapContextEnumToStr(ContextEnum context)
   {
     switch (context) {
       case eContextGenerator:
@@ -199,7 +199,7 @@ namespace OFX {
   }
 
   /** @brief map a std::string to a context */
-  InstanceChangeReason mapToInstanceChangedReason(const std::string &s) throw(std::invalid_argument)
+  InstanceChangeReason mapToInstanceChangedReason(const std::string &s)
   {
     if(s == kOfxChangePluginEdited) return eChangePluginEdit;
     if(s == kOfxChangeUserEdited) return eChangeUserEdit;
@@ -209,7 +209,7 @@ namespace OFX {
   }
 
   /** @brief turns a bit depth string into and enum */
-  BitDepthEnum mapStrToBitDepthEnum(const std::string &str) throw(std::invalid_argument)
+  BitDepthEnum mapStrToBitDepthEnum(const std::string &str)
   {
     if(str == kOfxBitDepthByte) {
       return eBitDepthUByte;
@@ -232,7 +232,7 @@ namespace OFX {
   }
 
   /** @brief turns a bit depth string into and enum */
-  const char* mapBitDepthEnumToStr(BitDepthEnum bitDepth) throw(std::invalid_argument)
+  const char* mapBitDepthEnumToStr(BitDepthEnum bitDepth)
   {
     switch (bitDepth) {
       case eBitDepthUByte:
@@ -254,7 +254,7 @@ namespace OFX {
   }
 
   /** @brief turns a pixel component string into and enum */
-  PixelComponentEnum mapStrToPixelComponentEnum(const std::string &str) throw(std::invalid_argument)
+  PixelComponentEnum mapStrToPixelComponentEnum(const std::string &str)
   {
     if(str == kOfxImageComponentRGBA) {
       return ePixelComponentRGBA;
@@ -274,7 +274,7 @@ namespace OFX {
   }
 
   /** @brief turns a pixel component string into and enum */
-  const char* mapPixelComponentEnumToStr(PixelComponentEnum pixelComponent) throw(std::invalid_argument)
+  const char* mapPixelComponentEnumToStr(PixelComponentEnum pixelComponent)
   {
     switch (pixelComponent) {
       case ePixelComponentRGBA:
@@ -292,7 +292,7 @@ namespace OFX {
   }
 
   /** @brief turns a premultiplication string into and enum */
-  static PreMultiplicationEnum mapStrToPreMultiplicationEnum(const std::string &str) throw(std::invalid_argument)
+  static PreMultiplicationEnum mapStrToPreMultiplicationEnum(const std::string &str)
   {
     if(str == kOfxImageOpaque) {
       return eImageOpaque;
@@ -309,7 +309,7 @@ namespace OFX {
   }
 
   /** @brief turns a field string into and enum */
-  FieldEnum mapStrToFieldEnum(const std::string &str)  throw(std::invalid_argument)
+  FieldEnum mapStrToFieldEnum(const std::string &str)
   {
     if(str == kOfxImageFieldNone) {
       return eFieldNone;
@@ -917,7 +917,7 @@ namespace OFX {
       }
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown pixel depth property '%s' reported on clip '%s'", str.c_str(), _clipName.c_str());
       e = eBitDepthNone;
     }
@@ -936,7 +936,7 @@ namespace OFX {
       }
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown  pixel component type '%s' reported on clip '%s'", str.c_str(), _clipName.c_str());
       e = ePixelComponentNone;
     }
@@ -955,7 +955,7 @@ namespace OFX {
       }
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown  pixel component type '%s' reported on clip '%s'", str.c_str(), _clipName.c_str());
       e = ePixelComponentNone;
     }
@@ -987,7 +987,7 @@ namespace OFX {
       }
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown unmapped pixel depth property '%s' reported on clip '%s'", str.c_str(), _clipName.c_str());
       e = eBitDepthNone;
     }
@@ -1006,7 +1006,7 @@ namespace OFX {
       }
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown unmapped pixel component type '%s' reported on clip '%s'", str.c_str(), _clipName.c_str());
       e = ePixelComponentNone;
     }
@@ -1022,7 +1022,7 @@ namespace OFX {
       e = mapStrToPreMultiplicationEnum(str);
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown premultiplication type '%s' reported on clip %s!", str.c_str(), _clipName.c_str());
       e = eImageOpaque;
     }
@@ -1040,7 +1040,7 @@ namespace OFX {
         "Field order '%s' reported on a clip %s is invalid, it must be none, lower or upper.", str.c_str(), _clipName.c_str());
     }
     // gone wrong ?
-    catch(std::invalid_argument) {
+    catch(std::invalid_argument&) {
       OFX::Log::error(true, "Unknown field order '%s' reported on a clip %s.", str.c_str(), _clipName.c_str());
       e = eFieldNone;
     }
@@ -2061,7 +2061,7 @@ namespace OFX {
       try {
         args.fieldToRender = mapStrToFieldEnum(str);
       }
-      catch (std::invalid_argument) {
+      catch (std::invalid_argument&) {
         // dud field?
         OFX::Log::error(true, "Unknown field to render '%s'", str.c_str());
 
@@ -2162,7 +2162,7 @@ namespace OFX {
       try {
         args.fieldToRender = mapStrToFieldEnum(str);
       }
-      catch (std::invalid_argument) {
+      catch (std::invalid_argument&) {
         // dud field?
         OFX::Log::error(true, "Unknown field to render '%s'", str.c_str());
 
@@ -2777,7 +2777,7 @@ namespace OFX {
       }
 
       // catch memory
-      catch (std::bad_alloc)
+      catch (std::bad_alloc&)
       {
         stat = kOfxStatErrMemory;
       }
@@ -2857,7 +2857,7 @@ namespace OFX {
       }
 
       // catch host inadequate exceptions
-      catch (OFX::Exception::HostInadequate)
+      catch (OFX::Exception::HostInadequate&)
       {
 #      ifdef DEBUG
         std::cout << "Caught OFX::Exception::HostInadequate" << std::endl;
@@ -2866,7 +2866,7 @@ namespace OFX {
       }
 
       // catch exception due to a property being unknown to the host, implies something wrong with host if not caught further down
-      catch (OFX::Exception::PropertyUnknownToHost)
+      catch (OFX::Exception::PropertyUnknownToHost&)
       {
 #      ifdef DEBUG
         std::cout << "Caught OFX::Exception::PropertyUnknownToHost" << std::endl;
@@ -2875,7 +2875,7 @@ namespace OFX {
       }
 
       // catch memory
-      catch (std::bad_alloc)
+      catch (std::bad_alloc&)
       {
         stat = kOfxStatErrMemory;
       }

--- a/Support/Library/ofxsInteract.cpp
+++ b/Support/Library/ofxsInteract.cpp
@@ -324,7 +324,7 @@ namespace OFX {
     try {
       penViewportPosition.x = props.propGetInt(kOfxInteractPropPenViewportPosition, 0);
       penViewportPosition.y = props.propGetInt(kOfxInteractPropPenViewportPosition, 1);
-    } catch (OFX::Exception::PropertyUnknownToHost) {
+    } catch (OFX::Exception::PropertyUnknownToHost&) {
       // Introduced in OFX 1.2. Return (-1,-1) if not available
       penViewportPosition.x = penViewportPosition.y = -1.;
     }

--- a/Support/Library/ofxsParams.cpp
+++ b/Support/Library/ofxsParams.cpp
@@ -1369,7 +1369,7 @@ namespace OFX {
 
   /** @brief get the time of the nth key, nth must be between 0 and getNumKeys-1 */
   double 
-    ValueParam::getKeyTime(int nthKey) throw(OFX::Exception::Suite, std::out_of_range)
+    ValueParam::getKeyTime(int nthKey)
   {
     if(!OFX::Private::gParamSuite->paramGetKeyTime) throwHostMissingSuiteException("paramGetKeyTime");
     double v = 0;

--- a/Support/Library/ofxsProperty.cpp
+++ b/Support/Library/ofxsProperty.cpp
@@ -9,10 +9,7 @@ namespace OFX {
 
   static
   void throwPropertyException(OfxStatus stat,
-    const std::string &propName) throw(std::bad_alloc,
-    OFX::Exception::PropertyUnknownToHost,
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+    const std::string &propName)
   {
     switch (stat) 
     {
@@ -55,10 +52,7 @@ namespace OFX {
   PropertySet::~PropertySet() {}
 
   /** @brief, returns the dimension of the given property from this property set */
-  int PropertySet::propGetDimension(const char* property, bool throwOnFailure) const throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  int PropertySet::propGetDimension(const char* property, bool throwOnFailure) const
   {
     assert(_propHandle != 0);
     int dimension = 0;
@@ -74,10 +68,7 @@ namespace OFX {
   }
 
   /** @brief, resets the property to it's default value */
-  void PropertySet::propReset(const char* property) throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost,
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void PropertySet::propReset(const char* property)
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propReset(_propHandle, property);
@@ -88,10 +79,7 @@ namespace OFX {
   }
 
   /** @brief, Set a single dimension pointer property */
-  void PropertySet::propSetPointer(const char* property, void *value, int idx, bool throwOnFailure) throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void PropertySet::propSetPointer(const char* property, void *value, int idx, bool throwOnFailure)
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propSetPointer(_propHandle, property, idx, value);
@@ -104,10 +92,7 @@ namespace OFX {
   }
 
   /** @brief, Set a single dimension string property */
-  void PropertySet::propSetString(const char* property, const std::string &value, int idx, bool throwOnFailure) throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void PropertySet::propSetString(const char* property, const std::string &value, int idx, bool throwOnFailure)
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propSetString(_propHandle, property, idx, value.c_str());
@@ -120,10 +105,7 @@ namespace OFX {
   }
 
   /** @brief, Set a single dimension double property */
-  void PropertySet::propSetDouble(const char* property, double value, int idx, bool throwOnFailure) throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void PropertySet::propSetDouble(const char* property, double value, int idx, bool throwOnFailure)
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propSetDouble(_propHandle, property, idx, value);
@@ -136,10 +118,7 @@ namespace OFX {
   }
 
   /** @brief, Set a single dimension int property */
-  void PropertySet::propSetInt(const char* property, int value, int idx, bool throwOnFailure) throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void PropertySet::propSetInt(const char* property, int value, int idx, bool throwOnFailure)
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propSetInt(_propHandle, property, idx, value);
@@ -152,10 +131,7 @@ namespace OFX {
   }
 
   /** @brief, Set a multiple dimension double property */
-  void PropertySet::propSetDoubleN(const char* property, const double* values, int count, bool throwOnFailure) throw(std::bad_alloc,
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void PropertySet::propSetDoubleN(const char* property, const double* values, int count, bool throwOnFailure)
   {
     assert(_propHandle != 0);
     OfxStatus stat = gPropSuite->propSetDoubleN(_propHandle, property, count, values);
@@ -168,10 +144,7 @@ namespace OFX {
   }
 
   /** @brief Get single pointer property */
-  void*  PropertySet::propGetPointer(const char* property, int idx, bool throwOnFailure) const throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  void*  PropertySet::propGetPointer(const char* property, int idx, bool throwOnFailure) const
   {
     assert(_propHandle != 0);
     void *value = 0;
@@ -187,10 +160,7 @@ namespace OFX {
   }
 
   /** @brief Get single string property */
-  std::string PropertySet::propGetString(const char* property, int idx, bool throwOnFailure) const throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  std::string PropertySet::propGetString(const char* property, int idx, bool throwOnFailure) const
   {
     assert(_propHandle != 0);
     char *value = NULL;
@@ -205,10 +175,7 @@ namespace OFX {
   }
 
   /** @brief Get single double property */
-  double PropertySet::propGetDouble(const char* property, int idx, bool throwOnFailure) const throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  double PropertySet::propGetDouble(const char* property, int idx, bool throwOnFailure) const
   {
     assert(_propHandle != 0);
     double value = 0;
@@ -223,10 +190,7 @@ namespace OFX {
   }
 
   /** @brief Get single int property */
-  int PropertySet::propGetInt(const char* property, int idx, bool throwOnFailure) const throw(std::bad_alloc, 
-    OFX::Exception::PropertyUnknownToHost, 
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite)
+  int PropertySet::propGetInt(const char* property, int idx, bool throwOnFailure) const
   {
     assert(_propHandle != 0);
     int value = 0;
@@ -240,10 +204,7 @@ namespace OFX {
     return value;
   }
     
-  std::list<std::string> PropertySet::propGetNString(const char* property, bool throwOnFailure) const throw(std::bad_alloc,
-  OFX::Exception::PropertyUnknownToHost,
-  OFX::Exception::PropertyValueIllegalToHost,
-  OFX::Exception::Suite)
+  std::list<std::string> PropertySet::propGetNString(const char* property, bool throwOnFailure) const
   {
     assert(_propHandle != 0);
     std::list<std::string> ret;

--- a/Support/include/ofxsCore.h
+++ b/Support/include/ofxsCore.h
@@ -136,7 +136,7 @@ namespace OFX {
       operator OfxStatus() const {return _status;}
 
       /** @brief reimplemented from std::exception */
-      virtual const char * what () const throw () {return mapStatusToString(_status);}
+      virtual const char * what () const noexcept {return mapStatusToString(_status);}
 
     };
 
@@ -146,10 +146,10 @@ namespace OFX {
       std::string _what;
     public :
       PropertyUnknownToHost(const char *what) : _what(what) {}
-      virtual ~PropertyUnknownToHost() throw() {}
+      virtual ~PropertyUnknownToHost() noexcept {}
 
       /** @brief reimplemented from std::exception */
-      virtual const char * what () const throw ()
+      virtual const char * what () const noexcept
       {
         return _what.c_str();
       }
@@ -161,10 +161,10 @@ namespace OFX {
       std::string _what;
     public :
       PropertyValueIllegalToHost(const char *what) : _what(what) {}
-      virtual ~PropertyValueIllegalToHost() throw() {}
+      virtual ~PropertyValueIllegalToHost() noexcept {}
 
       /** @brief reimplemented from std::exception */
-      virtual const char * what () const throw ()
+      virtual const char * what () const noexcept
       {
         return _what.c_str();
       }
@@ -178,10 +178,10 @@ namespace OFX {
       std::string _what;
     public :
       TypeRequest(const char *what) : _what(what) {}
-      virtual ~TypeRequest() throw() {}
+      virtual ~TypeRequest() noexcept {}
 
       /** @brief reimplemented from std::exception */
-      virtual const char * what () const throw ()
+      virtual const char * what () const noexcept
       {
         return _what.c_str();
       }
@@ -198,10 +198,10 @@ namespace OFX {
       std::string _what;
     public :
       HostInadequate(const char *what) : _what(what) {}
-      virtual ~HostInadequate() throw() {}
+      virtual ~HostInadequate() noexcept {}
 
       /** @brief reimplemented from std::exception */
-      virtual const char * what () const throw ()
+      virtual const char * what () const noexcept
       {
         return _what.c_str();
       }
@@ -211,12 +211,10 @@ namespace OFX {
 
   /** @brief Throws an @ref OFX::Exception::Suite depending on the status flag passed in */
   void
-    throwSuiteStatusException(OfxStatus stat)
-    throw(OFX::Exception::Suite, std::bad_alloc);
+    throwSuiteStatusException(OfxStatus stat);
 
   void
-    throwHostMissingSuiteException(std::string name)
-    throw(OFX::Exception::Suite);
+    throwHostMissingSuiteException(std::string name);
 
   /** @brief This struct is used to return an identifier for the plugin by the function @ref OFX:Plugin::getPlugin.
   The members correspond to those in the OfxPlugin struct defined in ofxCore.h.
@@ -260,127 +258,67 @@ namespace OFX {
     /** @brief return the handle for this property set */
     OfxPropertySetHandle propSetHandle(void) const {return _propHandle;}
 
-    int  propGetDimension(const char* property, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
-    void propReset(const char* property) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    int  propGetDimension(const char* property, bool throwOnFailure = true) const;
+    void propReset(const char* property);
 
     // set single values
-    void propSetPointer(const char* property, void *value, int idx, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
-    void propSetString(const char* property, const std::string &value, int idx, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
-    void propSetDouble(const char* property, double value, int idx, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
-    void propSetInt(const char* property, int value, int idx, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    void propSetPointer(const char* property, void *value, int idx, bool throwOnFailure = true);
+    void propSetString(const char* property, const std::string &value, int idx, bool throwOnFailure = true);
+    void propSetDouble(const char* property, double value, int idx, bool throwOnFailure = true);
+    void propSetInt(const char* property, int value, int idx, bool throwOnFailure = true);
 
     // set multiple values
-    void propSetDoubleN(const char* property, const double *value, int count, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    void propSetDoubleN(const char* property, const double *value, int count, bool throwOnFailure = true);
 
-    void propSetPointer(const char* property, void *value, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    void propSetPointer(const char* property, void *value, bool throwOnFailure = true)
     {propSetPointer(property, value, 0, throwOnFailure);}
 
-    void propSetString(const char* property, const std::string &value, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    void propSetString(const char* property, const std::string &value, bool throwOnFailure = true)
     {propSetString(property, value, 0, throwOnFailure);}
 
-    void propSetDouble(const char* property, double value, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    void propSetDouble(const char* property, double value, bool throwOnFailure = true)
     {propSetDouble(property, value, 0, throwOnFailure);}
 
-    void propSetInt(const char* property, int value, bool throwOnFailure = true) throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    void propSetInt(const char* property, int value, bool throwOnFailure = true)
     {propSetInt(property, value, 0, throwOnFailure);}
 
 
     /// get a pointer property
-    void       *propGetPointer(const char* property, int idx, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    void       *propGetPointer(const char* property, int idx, bool throwOnFailure = true) const;
 
     /// get a string property
-    std::string propGetString(const char* property, int idx, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    std::string propGetString(const char* property, int idx, bool throwOnFailure = true) const;
     /// get a double property
-    double      propGetDouble(const char* property, int idx, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    double      propGetDouble(const char* property, int idx, bool throwOnFailure = true) const;
 
     /// get an int property
-    int propGetInt(const char* property, int idx, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite);
+    int propGetInt(const char* property, int idx, bool throwOnFailure = true) const;
 
     /// get a pointer property with index 0
-    void* propGetPointer(const char* property, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    void* propGetPointer(const char* property, bool throwOnFailure = true) const
     {
       return propGetPointer(property, 0, throwOnFailure);
     }
 
     /// get a string property with index 0
-    std::string propGetString(const char* property, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    std::string propGetString(const char* property, bool throwOnFailure = true) const
     {
       return propGetString(property, 0, throwOnFailure);
     }
 
     /// get a double property with index 0
-    double propGetDouble(const char* property, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    double propGetDouble(const char* property, bool throwOnFailure = true) const
     {
       return propGetDouble(property, 0, throwOnFailure);
     }
 
     /// get an int property with index 0
-    int propGetInt(const char* property, bool throwOnFailure = true) const throw(std::bad_alloc,
-      OFX::Exception::PropertyUnknownToHost,
-      OFX::Exception::PropertyValueIllegalToHost,
-      OFX::Exception::Suite)
+    int propGetInt(const char* property, bool throwOnFailure = true) const
     {
       return propGetInt(property, 0, throwOnFailure);
     }
 
-    std::list<std::string> propGetNString(const char* property, bool throwOnFailure = true) const throw(std::bad_alloc,
-    OFX::Exception::PropertyUnknownToHost,
-    OFX::Exception::PropertyValueIllegalToHost,
-    OFX::Exception::Suite);
+    std::list<std::string> propGetNString(const char* property, bool throwOnFailure = true) const;
 
   };
 

--- a/Support/include/ofxsImageEffect.h
+++ b/Support/include/ofxsImageEffect.h
@@ -117,27 +117,27 @@ namespace OFX {
   };
 
   /** @brief turns a field string into and enum */
-  FieldEnum mapStrToFieldEnum(const std::string &str)  throw(std::invalid_argument);
+  FieldEnum mapStrToFieldEnum(const std::string &str);
 
   ////////////////////////////////////////////////////////////////////////////////
   /** @brief map a std::string to a context enum */
-  ContextEnum mapToContextEnum(const std::string &s) throw(std::invalid_argument);
+  ContextEnum mapToContextEnum(const std::string &s);
 
-  const char* mapContextEnumToStr(ContextEnum context) throw(std::invalid_argument);
+  const char* mapContextEnumToStr(ContextEnum context);
 
   const char* mapMessageTypeEnumToStr(OFX::Message::MessageTypeEnum type);
 
   OFX::Message::MessageReplyEnum mapToMessageReplyEnum(OfxStatus stat);
 
-  InstanceChangeReason mapToInstanceChangedReason(const std::string &s) throw(std::invalid_argument);
+  InstanceChangeReason mapToInstanceChangedReason(const std::string &s);
 
-  BitDepthEnum mapStrToBitDepthEnum(const std::string &str) throw(std::invalid_argument);
+  BitDepthEnum mapStrToBitDepthEnum(const std::string &str);
 
-  const char* mapBitDepthEnumToStr(BitDepthEnum bitDepth) throw(std::invalid_argument);
+  const char* mapBitDepthEnumToStr(BitDepthEnum bitDepth);
 
-  PixelComponentEnum mapStrToPixelComponentEnum(const std::string &str) throw(std::invalid_argument);
+  PixelComponentEnum mapStrToPixelComponentEnum(const std::string &str);
 
-  const char* mapPixelComponentEnumToStr(PixelComponentEnum pixelComponent) throw(std::invalid_argument);
+  const char* mapPixelComponentEnumToStr(PixelComponentEnum pixelComponent);
 
   class PluginFactory
   {

--- a/Support/include/ofxsMemory.h
+++ b/Support/include/ofxsMemory.h
@@ -26,16 +26,16 @@ namespace OFX {
     This function has the host allocate memory using it's own memory resources
     and returns that to the plugin. This memory is distinct to any image memory allocation.
 
-    Suceeds or throws std::bad_alloc
+    Succeeds or throws std::bad_alloc
     */   
     void *allocate(size_t nBytes,
-      ImageEffect *handle = 0) throw(std::bad_alloc);
+      ImageEffect *handle = 0);
 
     /** @brief release memory
 
     \arg \e ptr	      - pointer previously returned by OFX::Memory::allocate
     */
-    void free(void *ptr) throw();
+    void free(void *ptr) noexcept;
   };
 
 };

--- a/Support/include/ofxsParam.h
+++ b/Support/include/ofxsParam.h
@@ -939,7 +939,7 @@ namespace OFX {
         unsigned int getNumKeys(void);
 
         /** @brief get the time of the nth key, nth must be between 0 and getNumKeys-1 */
-        double getKeyTime(int nthKey) throw(OFX::Exception::Suite, std::out_of_range);
+        double getKeyTime(int nthKey);
 
         /** @brief find the index of a key by a time */
         int getKeyIndex(double time, 


### PR DESCRIPTION
Removes dynamic exception specifications and fixes "catching polymorphic type" warnings. Exception specifications were deprecated in C++11 and removed in C++17. This should address [ issue  #82](https://github.com/AcademySoftwareFoundation/openfx/issues/82).