### PR TITLE
Replace deprecated auto_ptr with unique_ptr.

### DIFF
--- a/HostSupport/examples/hostDemo.cpp
+++ b/HostSupport/examples/hostDemo.cpp
@@ -108,9 +108,9 @@ int main(int argc, char **argv)
     // create an instance of it as a filter
     // the first arg is the context, the second is client data we are allowed to pass down the call chain
 
-    std::auto_ptr<OFX::Host::ImageEffect::Instance> instance(plugin->createInstance(kOfxImageEffectContextFilter, NULL));
+    std::unique_ptr<OFX::Host::ImageEffect::Instance> instance(plugin->createInstance(kOfxImageEffectContextFilter, NULL));
 
-    if(instance.get())
+    if(instance)
     {
         OfxStatus stat;
 

--- a/HostSupport/include/ofxhImageEffectAPI.h
+++ b/HostSupport/include/ofxhImageEffectAPI.h
@@ -34,12 +34,12 @@ namespace OFX {
         Descriptor *_baseDescriptor; /// NEEDS TO BE MADE WITH A FACTORY FUNCTION ON THE HOST!!!!!!
         
         /// map to store contexts in
-        std::map<std::string, Descriptor *> _contexts;
+        std::map<std::string, std::unique_ptr<Descriptor>> _contexts;
 
         mutable std::set<std::string> _knownContexts;
         mutable bool _madeKnownContexts;
 
-        std::auto_ptr<PluginHandle> _pluginHandle;
+        std::unique_ptr<PluginHandle> _pluginHandle;
 
         void addContextInternal(const std::string &context) const;
 
@@ -72,7 +72,7 @@ namespace OFX {
         Descriptor *getContext(const std::string &context);
 
         void addContext(const std::string &context);
-        void addContext(const std::string &context, Descriptor *ied);
+        void addContext(const std::string &context, std::unique_ptr<Descriptor> ied);
 
         virtual void saveXML(std::ostream &os);
 

--- a/Support/Plugins/Basic/basic.cpp
+++ b/Support/Plugins/Basic/basic.cpp
@@ -262,12 +262,12 @@ void
 BasicPlugin::setupAndProcess(ImageScalerBase &processor, const OFX::RenderArguments &args)
 {
   // get a dst image
-  std::auto_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
   OFX::BitDepthEnum dstBitDepth       = dst->getPixelDepth();
   OFX::PixelComponentEnum dstComponents  = dst->getPixelComponents();
 
   // fetch main input image
-  std::auto_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
 
   // make sure bit depths are sane
   if(src.get()) {
@@ -279,13 +279,11 @@ BasicPlugin::setupAndProcess(ImageScalerBase &processor, const OFX::RenderArgume
       throw int(1); // HACK!! need to throw an sensible exception here!
   }
 
-  // auto ptr for the mask.
-  // Should do this inside the if statement below but the MS compiler I have doesn't have
-  // a 'reset' function on the auto_ptr class
-  std::auto_ptr<OFX::Image> mask(getContext() != OFX::eContextFilter ? maskClip_->fetchImage(args.time) : 0);
+  std::unique_ptr<OFX::Image> mask;
 
   // do we do masking
   if(getContext() != OFX::eContextFilter) {
+    mask.reset(maskClip_->fetchImage(args.time));
     // say we are masking
     processor.doMasking(true);
 

--- a/Support/Plugins/Field/field.cpp
+++ b/Support/Plugins/Field/field.cpp
@@ -123,12 +123,12 @@ void
 FieldPlugin::setupAndProcess(FieldBase &processor, const OFX::RenderArguments &args)
 {
   // get a dst image
-  std::auto_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
   OFX::BitDepthEnum dstBitDepth       = dst->getPixelDepth();
   OFX::PixelComponentEnum dstComponents  = dst->getPixelComponents();
 
   // fetch main input image
-  std::auto_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
 
   // make sure bit depths are sane
   if(src.get()) {

--- a/Support/Plugins/Generator/noise.cpp
+++ b/Support/Plugins/Generator/noise.cpp
@@ -124,7 +124,7 @@ void
 NoisePlugin::setupAndProcess(NoiseGeneratorBase &processor, const OFX::RenderArguments &args)
 {
   // get a dst image
-  std::auto_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
   //OFX::BitDepthEnum         dstBitDepth    = dst->getPixelDepth();
   //OFX::PixelComponentEnum   dstComponents  = dst->getPixelComponents();
 

--- a/Support/Plugins/Invert/invert.cpp
+++ b/Support/Plugins/Invert/invert.cpp
@@ -108,12 +108,12 @@ void
 InvertPlugin::setupAndProcess(InvertBase &processor, const OFX::RenderArguments &args)
 {
   // get a dst image
-  std::auto_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
   OFX::BitDepthEnum dstBitDepth       = dst->getPixelDepth();
   OFX::PixelComponentEnum dstComponents  = dst->getPixelComponents();
 
   // fetch main input image
-  std::auto_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
 
   // make sure bit depths are sane
   if(src.get()) {

--- a/Support/Plugins/MultiBundle/multibundle1.cpp
+++ b/Support/Plugins/MultiBundle/multibundle1.cpp
@@ -177,10 +177,10 @@ public :
 
 void GammaPlugin::setupAndProcess(ImageScalerBase &processor, const OFX::RenderArguments &args)
 {
-  std::auto_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
   OFX::BitDepthEnum dstBitDepth       = dst->getPixelDepth();
   OFX::PixelComponentEnum dstComponents  = dst->getPixelComponents();
-  std::auto_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
   if(src.get()) 
   {
     OFX::BitDepthEnum    srcBitDepth      = src->getPixelDepth();
@@ -188,9 +188,10 @@ void GammaPlugin::setupAndProcess(ImageScalerBase &processor, const OFX::RenderA
     if(srcBitDepth != dstBitDepth || srcComponents != dstComponents)
       throw int(1);
   }
-  std::auto_ptr<OFX::Image> mask(getContext() != OFX::eContextFilter ? maskClip_->fetchImage(args.time) : 0);
+  std::unique_ptr<OFX::Image> mask;
   if(getContext() != OFX::eContextFilter) 
   {
+    mask.reset(maskClip_->fetchImage(args.time));
     processor.doMasking(true);
     processor.setMaskImg(mask.get());
   }

--- a/Support/Plugins/MultiBundle/multibundle2.cpp
+++ b/Support/Plugins/MultiBundle/multibundle2.cpp
@@ -146,7 +146,7 @@ void DotExamplePlugin::getPositionInPixels(double& x, double& y, const ARGS& arg
 
 void DotExamplePlugin::setupAndProcess(DotGeneratorBase &processor, const OFX::RenderArguments &args)
 {
-  std::auto_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
   //OFX::BitDepthEnum         dstBitDepth    = dst->getPixelDepth();
   //OFX::PixelComponentEnum   dstComponents  = dst->getPixelComponents();
   double rad = radius_->getValueAtTime(args.time);

--- a/Support/Plugins/Retimer/retimer.cpp
+++ b/Support/Plugins/Retimer/retimer.cpp
@@ -125,7 +125,7 @@ void
 RetimerPlugin::setupAndProcess(OFX::ImageBlenderBase &processor, const OFX::RenderArguments &args)
 {
     // get a dst image
-    std::auto_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
+    std::unique_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
     OFX::BitDepthEnum          dstBitDepth    = dst->getPixelDepth();
     OFX::PixelComponentEnum    dstComponents  = dst->getPixelComponents();
   
@@ -147,8 +147,8 @@ RetimerPlugin::setupAndProcess(OFX::ImageBlenderBase &processor, const OFX::Rend
     framesNeeded(sourceTime, args.fieldToRender, &fromTime, &toTime, &blend);
 
     // fetch the two source images
-    std::auto_ptr<OFX::Image> fromImg(srcClip_->fetchImage(fromTime));
-    std::auto_ptr<OFX::Image> toImg(srcClip_->fetchImage(toTime));
+    std::unique_ptr<OFX::Image> fromImg(srcClip_->fetchImage(fromTime));
+    std::unique_ptr<OFX::Image> toImg(srcClip_->fetchImage(toTime));
 
     // make sure bit depths are sane
     if(fromImg.get()) checkComponents(*fromImg, dstBitDepth, dstComponents);

--- a/Support/Plugins/Tester/Tester.cpp
+++ b/Support/Plugins/Tester/Tester.cpp
@@ -228,7 +228,7 @@ public:
     OfxRangeD range = srcClip->getFrameRange();
     for(double d = range.min; d< range.max; ++d)
     {
-      std::auto_ptr<OFX::Image> src(srcClip->fetchImage(d));
+      std::unique_ptr<OFX::Image> src(srcClip->fetchImage(d));
       dbl->setValueAtTime(d, d);
     }
   }
@@ -328,10 +328,10 @@ public :
 
 void GenericTestPlugin::setupAndProcess(GenericTestBase &processor, const OFX::RenderArguments &args)
 {
-  std::auto_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> dst(dstClip_->fetchImage(args.time));
   OFX::BitDepthEnum dstBitDepth       = dst->getPixelDepth();
   OFX::PixelComponentEnum dstComponents  = dst->getPixelComponents();
-  std::auto_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> src(srcClip_->fetchImage(args.time));
 
   if(src.get()) 
   {

--- a/Support/Plugins/Transition/crossFade.cpp
+++ b/Support/Plugins/Transition/crossFade.cpp
@@ -71,13 +71,13 @@ void
 CrossFadePlugin::setupAndProcess(OFX::ImageBlenderBase &processor, const OFX::RenderArguments &args)
 {
   // get a dst image
-  std::auto_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image>  dst(dstClip_->fetchImage(args.time));
   OFX::BitDepthEnum          dstBitDepth    = dst->getPixelDepth();
   OFX::PixelComponentEnum    dstComponents  = dst->getPixelComponents();
 
   // fetch the two source images
-  std::auto_ptr<OFX::Image> fromImg(fromClip_->fetchImage(args.time));
-  std::auto_ptr<OFX::Image> toImg(toClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> fromImg(fromClip_->fetchImage(args.time));
+  std::unique_ptr<OFX::Image> toImg(toClip_->fetchImage(args.time));
 
   // make sure bit depths are sane
   if(fromImg.get()) checkComponents(*fromImg, dstBitDepth, dstComponents);

--- a/Support/include/ofxsImageEffect.h
+++ b/Support/include/ofxsImageEffect.h
@@ -364,7 +364,7 @@ namespace OFX {
     std::map<std::string, std::string> _clipROIPropNames;
     std::map<std::string, std::string> _clipFrameRangePropNames;
 
-    std::auto_ptr<EffectOverlayDescriptor> _overlayDescriptor;
+    std::unique_ptr<EffectOverlayDescriptor> _overlayDescriptor;
   public :
     /** @brief ctor */
     ImageEffectDescriptor(OfxImageEffectHandle handle);

--- a/Support/include/ofxsParam.h
+++ b/Support/include/ofxsParam.h
@@ -229,7 +229,7 @@ namespace OFX {
         ValueParamDescriptor(const std::string &name, ParamTypeEnum type, OfxPropertySetHandle props);
 
         friend class ParamSetDescriptor;
-        std::auto_ptr<ParamInteractDescriptor> _interact;
+        std::unique_ptr<ParamInteractDescriptor> _interact;
     public :
         /** @brief dtor */
         ~ValueParamDescriptor();
@@ -659,7 +659,7 @@ namespace OFX {
 
         OfxParamHandle _ofxParamHandle;
         ParamSetDescriptor* _paramSet;
-        std::auto_ptr<ParamInteractDescriptor> _interact;
+        std::unique_ptr<ParamInteractDescriptor> _interact;
 
         // so it can make one
         friend class ParamSetDescriptor;


### PR DESCRIPTION
Replaced all std::auto_ptr usage with std::unique_ptr usage. auto_ptr was deprecated in C++11 and was removed in C++17. I tried to make minimal changes that would preserve behavior and avoid changing too many function signatures. 