### PR TITLE
Fix Example Makefile to build on OSX and Linux

### DIFF
--- a/Documentation/sources/Guide/Code/Example1/basics.cpp
+++ b/Documentation/sources/Guide/Code/Example1/basics.cpp
@@ -24,7 +24,7 @@
 // the one OFX header we need, it includes the others necessary
 #include "ofxImageEffect.h"
 
-#if defined __APPLE__ || defined linux
+#if defined __APPLE__ || defined __linux__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Documentation/sources/Guide/Code/Example2/invert.cpp
+++ b/Documentation/sources/Guide/Code/Example2/invert.cpp
@@ -19,7 +19,7 @@
 // the one OFX header we need, it includes the others necessary
 #include "ofxImageEffect.h"
 
-#if defined __APPLE__ || defined linux
+#if defined __APPLE__ || defined __linux__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Documentation/sources/Guide/Code/Example3/gain.cpp
+++ b/Documentation/sources/Guide/Code/Example3/gain.cpp
@@ -21,7 +21,7 @@
 // the one OFX header we need, it includes the others necessary
 #include "ofxImageEffect.h"
 
-#if defined __APPLE__ || defined linux
+#if defined __APPLE__ || defined __linux__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Documentation/sources/Guide/Code/Example4/saturation.cpp
+++ b/Documentation/sources/Guide/Code/Example4/saturation.cpp
@@ -21,7 +21,7 @@
 // the one OFX header we need, it includes the others necessary
 #include "ofxImageEffect.h"
 
-#if defined __APPLE__ || defined linux
+#if defined __APPLE__ || defined __linux__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Documentation/sources/Guide/Code/Example5/circle.cpp
+++ b/Documentation/sources/Guide/Code/Example5/circle.cpp
@@ -21,7 +21,7 @@
 // the one OFX header we need, it includes the others necessary
 #include "ofxImageEffect.h"
 
-#if defined __APPLE__ || defined linux
+#if defined __APPLE__ || defined __linux__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Basic/basic.cpp
+++ b/Examples/Basic/basic.cpp
@@ -32,7 +32,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Custom/custom.cpp
+++ b/Examples/Custom/custom.cpp
@@ -28,7 +28,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/DepthConverter/depthConverter.cpp
+++ b/Examples/DepthConverter/depthConverter.cpp
@@ -20,7 +20,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/DrawSuite/drawsuite.cpp
+++ b/Examples/DrawSuite/drawsuite.cpp
@@ -27,7 +27,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Invert/invert.cpp
+++ b/Examples/Invert/invert.cpp
@@ -21,7 +21,7 @@
 #include "ofxMultiThread.h"
 #include "ofxPixels.h"
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Makefile.master
+++ b/Examples/Makefile.master
@@ -24,16 +24,18 @@ ifeq ($(DEBUGFLAG),-O3)
   DEBUGNAME = release
 endif
 
+CXXSTANDARD ?= --std=c++11
+
 OBJECTPATH = $(OS)-$(BITS)-$(DEBUGNAME)
 
 $(OBJECTPATH)/%.o : %.cpp
 	mkdir -p $(OBJECTPATH)
-	$(CXX) -c $(CXXFLAGS) $< -o $@
+	$(CXX) -c $(CXXFLAGS) $(CXXSTANDARD) $(CXXARCH) $< -o $@
 
 all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
 
   ifeq ($(OS),$(filter $(OS),MINGW64_NT-6.1 MINGW32_NT-6.1))
-    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/include/linuxSymbols -lopengl32
+    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/../symbols/linux.symbols -lopengl32
     ARCH = Win32
     BITSFLAG = -m32
     ifeq ($(BITS), 64)
@@ -44,7 +46,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
   endif
   ifeq ($(OS),Linux)
     # use $ORIGIN to link to bundled libraries first, see http://itee.uq.edu.au/~daniel/using_origin/
-    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/include/linuxSymbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
+    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/../symbols/linux.symbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
     ARCH = Linux-x86
     BITSFLAG = -m32 -fPIC
     ifeq ($(BITS), 64)
@@ -54,7 +56,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
     LINKFLAGS := $(LINKFLAGS) $(BITSFLAG)
   endif
   ifeq ($(OS),FreeBSD)
-    LINKFLAGS = -L/usr/local/lib -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/include/linuxSymbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
+    LINKFLAGS = -L/usr/local/lib -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/../symbols/linux.symbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
     ARCH= FreeBSD-x86
     BITSFLAG = -m32 -fPIC
     ifeq ($(BITS), 64)
@@ -84,7 +86,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
       endif
       BITSFLAG = -isysroot /Developer/SDKs/MacOSX$(MACOSXSDK).sdk $(ARCHFLAGS) -mmacosx-version-min=$(MACOSX) -fPIC
     endif
-    LINKFLAGS = $(BITSFLAG) -bundle -fvisibility=hidden -exported_symbols_list $(PATHTOROOT)/include/osxSymbols -framework OpenGL -Wl,-rpath,@loader_path/../Frameworks -Wl,-rpath,@loader_path/../Libraries
+    LINKFLAGS = $(BITSFLAG) -bundle -fvisibility=hidden -exported_symbols_list $(PATHTOROOT)/../symbols/osx.symbols -framework OpenGL -Wl,-rpath,@loader_path/../Frameworks -Wl,-rpath,@loader_path/../Libraries
     ARCH = MacOS
   endif
 

--- a/Examples/OpenGL/opengl.cpp
+++ b/Examples/OpenGL/opengl.cpp
@@ -26,7 +26,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Overlay/overlay.cpp
+++ b/Examples/Overlay/overlay.cpp
@@ -31,7 +31,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Rectangle/rectangle.cpp
+++ b/Examples/Rectangle/rectangle.cpp
@@ -25,7 +25,7 @@
 
 #include "../include/ofxUtilities.H" // example support utils
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Examples/Test/testProperties.cpp
+++ b/Examples/Test/testProperties.cpp
@@ -18,7 +18,7 @@ run it through a c beautifier or emacs auto formatting, automagic indenting will
 
 #include "ofxLog.H"
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 #  define EXPORT __attribute__((visibility("default")))
 #elif defined _WIN32
 #  define EXPORT OfxExport

--- a/Support/Library/ofxsImageEffect.cpp
+++ b/Support/Library/ofxsImageEffect.cpp
@@ -15,7 +15,7 @@
 #endif
 #include "ofxsCore.h"
 
-#if defined __APPLE__ || defined linux || defined __FreeBSD__
+#if defined __APPLE__ || defined __linux__ || defined __FreeBSD__
 # if __GNUC__ >= 4
 #  define EXPORT __attribute__((visibility("default")))
 #  define LOCAL  __attribute__((visibility("hidden")))


### PR DESCRIPTION
Also use __linux__, proper modern preprocessor symbol.

Closes #117.