### PR TITLE
Add OpenCL Image support to the updated GPU rendering extension:

### DIFF
--- a/Examples/GPUGain/OpenCLKernel.cpp
+++ b/Examples/GPUGain/OpenCLKernel.cpp
@@ -15,8 +15,8 @@
 #include <CL/cl.h>
 #endif
 
-const char *KernelSource = "\n" \
-"__kernel void GainAdjustKernel(                                        \n" \
+const char *KernelSourceBuffers = "\n" \
+"__kernel void GainAdjustKernelBuffers(                                 \n" \
 "   int p_Width,                                                        \n" \
 "   int p_Height,                                                       \n" \
 "   float p_GainR,                                                      \n" \
@@ -39,6 +39,32 @@ const char *KernelSource = "\n" \
 "       p_Output[index + 3] = p_Input[index + 3] * p_GainA;             \n" \
 "   }                                                                   \n" \
 "}                                                                      \n" \
+"\n";
+
+const char *KernelSourceImages = "\n" \
+"__constant sampler_t imageSampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;  \n" \
+"                                                                                                           \n" \
+"__kernel void GainAdjustKernelImages(                                                                      \n" \
+"   int p_Width,                                                                                            \n" \
+"   int p_Height,                                                                                           \n" \
+"   float p_GainR,                                                                                          \n" \
+"   float p_GainG,                                                                                          \n" \
+"   float p_GainB,                                                                                          \n" \
+"   float p_GainA,                                                                                          \n" \
+"   __read_only  image2d_t p_Input,                                                                         \n" \
+"   __write_only image2d_t p_Output)                                                                        \n" \
+"{                                                                                                          \n" \
+"   const int x = get_global_id(0);                                                                         \n" \
+"   const int y = get_global_id(1);                                                                         \n" \
+"                                                                                                           \n" \
+"   if ((x < p_Width) && (y < p_Height))                                                                    \n" \
+"   {                                                                                                       \n" \
+"       int2 coord = (int2)(x, y);                                                                          \n" \
+"       float4 out = read_imagef(p_Input, imageSampler, coord);                                             \n" \
+"       out *= (float4)(p_GainR, p_GainG, p_GainB, p_GainA);                                                \n" \
+"       write_imagef(p_Output, coord, out);                                                                 \n" \
+"   }                                                                                                       \n" \
+"}                                                                                                          \n" \
 "\n";
 
 void CheckError(cl_int p_Error, const char* p_Msg)
@@ -96,7 +122,7 @@ private:
 #endif
 };
 
-void RunOpenCLKernel(void* p_CmdQ, int p_Width, int p_Height, float* p_Gain, const float* p_Input, float* p_Output)
+void RunOpenCLKernelBuffers(void* p_CmdQ, int p_Width, int p_Height, float* p_Gain, const float* p_Input, float* p_Output)
 {
     cl_int error;
 
@@ -132,13 +158,13 @@ void RunOpenCLKernel(void* p_CmdQ, int p_Width, int p_Height, float* p_Gain, con
         error = clGetCommandQueueInfo(cmdQ, CL_QUEUE_CONTEXT, sizeof(cl_context), &clContext, NULL);
         CheckError(error, "Unable to get the context");
 
-        cl_program program = clCreateProgramWithSource(clContext, 1, (const char **)&KernelSource, NULL, &error);
+        cl_program program = clCreateProgramWithSource(clContext, 1, (const char **)&KernelSourceBuffers, NULL, &error);
         CheckError(error, "Unable to create program");
 
         error = clBuildProgram(program, 0, NULL, NULL, NULL, NULL);
         CheckError(error, "Unable to build program");
 
-        kernel = clCreateKernel(program, "GainAdjustKernel", &error);
+        kernel = clCreateKernel(program, "GainAdjustKernelBuffers", &error);
         CheckError(error, "Unable to create kernel");
 
         kernelMap[cmdQ] = kernel;
@@ -152,6 +178,80 @@ void RunOpenCLKernel(void* p_CmdQ, int p_Width, int p_Height, float* p_Gain, con
 
     int count = 0;
     error  = clSetKernelArg(kernel, count++, sizeof(int), &p_Width);
+    error |= clSetKernelArg(kernel, count++, sizeof(int), &p_Height);
+    error |= clSetKernelArg(kernel, count++, sizeof(float), &p_Gain[0]);
+    error |= clSetKernelArg(kernel, count++, sizeof(float), &p_Gain[1]);
+    error |= clSetKernelArg(kernel, count++, sizeof(float), &p_Gain[2]);
+    error |= clSetKernelArg(kernel, count++, sizeof(float), &p_Gain[3]);
+    error |= clSetKernelArg(kernel, count++, sizeof(cl_mem), &p_Input);
+    error |= clSetKernelArg(kernel, count++, sizeof(cl_mem), &p_Output);
+    CheckError(error, "Unable to set kernel arguments");
+
+    size_t localWorkSize[2], globalWorkSize[2];
+    clGetKernelWorkGroupInfo(kernel, deviceId, CL_KERNEL_WORK_GROUP_SIZE, sizeof(size_t), localWorkSize, NULL);
+    localWorkSize[1] = 1;
+    globalWorkSize[0] = ((p_Width + localWorkSize[0] - 1) / localWorkSize[0]) * localWorkSize[0];
+    globalWorkSize[1] = p_Height;
+
+    clEnqueueNDRangeKernel(cmdQ, kernel, 2, NULL, globalWorkSize, localWorkSize, 0, NULL, NULL);
+}
+
+void RunOpenCLKernelImages(void* p_CmdQ, int p_Width, int p_Height, float* p_Gain, const float* p_Input, float* p_Output)
+{
+    cl_int error;
+
+    cl_command_queue cmdQ = static_cast<cl_command_queue>(p_CmdQ);
+
+    // store device id and kernel per command queue (required for multi-GPU systems)
+    static std::map<cl_command_queue, cl_device_id> deviceIdMap;
+    static std::map<cl_command_queue, cl_kernel> kernelMap;
+
+    static Locker locker; // simple lock to control access to the above maps from multiple threads
+
+    locker.Lock();
+
+    // find the device id corresponding to the command queue
+    cl_device_id deviceId = NULL;
+    if (deviceIdMap.find(cmdQ) == deviceIdMap.end())
+    {
+        error = clGetCommandQueueInfo(cmdQ, CL_QUEUE_DEVICE, sizeof(cl_device_id), &deviceId, NULL);
+        CheckError(error, "Unable to get the device");
+
+        deviceIdMap[cmdQ] = deviceId;
+    }
+    else
+    {
+        deviceId = deviceIdMap[cmdQ];
+    }
+
+    // find the program kernel corresponding to the command queue
+    cl_kernel kernel = NULL;
+    if (kernelMap.find(cmdQ) == kernelMap.end())
+    {
+        cl_context clContext = NULL;
+        error = clGetCommandQueueInfo(cmdQ, CL_QUEUE_CONTEXT, sizeof(cl_context), &clContext, NULL);
+        CheckError(error, "Unable to get the context");
+
+        cl_program program = clCreateProgramWithSource(clContext, 1, (const char **)&KernelSourceImages, NULL, &error);
+        CheckError(error, "Unable to create program");
+
+        error = clBuildProgram(program, 0, NULL, NULL, NULL, NULL);
+        CheckError(error, "Unable to build program");
+
+        kernel = clCreateKernel(program, "GainAdjustKernelImages", &error);
+        CheckError(error, "Unable to create kernel");
+
+        kernelMap[cmdQ] = kernel;
+    }
+    else
+    {
+        kernel = kernelMap[cmdQ];
+    }
+
+    locker.Unlock();
+
+    int count = 0;
+    error = clSetKernelArg(kernel, count++, sizeof(int), &p_Width);
     error |= clSetKernelArg(kernel, count++, sizeof(int), &p_Height);
     error |= clSetKernelArg(kernel, count++, sizeof(float), &p_Gain[0]);
     error |= clSetKernelArg(kernel, count++, sizeof(float), &p_Gain[1]);

--- a/Support/Library/ofxsImageEffect.cpp
+++ b/Support/Library/ofxsImageEffect.cpp
@@ -667,10 +667,16 @@ namespace OFX {
     }
   }
 
-  /** @brief Does the plugin support OpenCL Render */
-  void ImageEffectDescriptor::setSupportsOpenCLRender(bool v)
+  /** @brief Does the plugin support OpenCL Buffers Render */
+  void ImageEffectDescriptor::setSupportsOpenCLBuffersRender(bool v)
   {
       _effectProps.propSetString(kOfxImageEffectPropOpenCLRenderSupported, (v ? "true" : "false"));
+  }
+
+  /** @brief Does the plugin support OpenCL Images Render */
+  void ImageEffectDescriptor::setSupportsOpenCLImagesRender(bool v)
+  {
+      _effectProps.propSetString(kOfxImageEffectPropOpenCLSupported, (v ? "true" : "false"));
   }
 
   /** @brief Does the plugin support CUDA Render */
@@ -759,7 +765,7 @@ namespace OFX {
     OFX::Validation::validateImageBaseProperties(props);
 
     // and fetch all the properties
-    _rowBytes         = _imageProps.propGetInt(kOfxImagePropRowBytes);
+    _rowBytes         = _imageProps.propGetInt(kOfxImagePropRowBytes, /*throwOnFailure*/false); // not required for OpenCL Images
     _pixelAspectRatio = _imageProps.propGetDouble(kOfxImagePropPixelAspectRatio);;
       
     std::string str  = _imageProps.propGetString(kOfxImageEffectPropComponents);
@@ -849,8 +855,10 @@ namespace OFX {
     OFX::Validation::validateImageProperties(props);
 
     // and fetch all the properties
+    _OpenCLImage = nullptr;
+    _OpenCLImage = _imageProps.propGetPointer(kOfxImageEffectPropOpenCLImage, /*throwOnFailure*/false);
     // should throw if it is not an image
-    _pixelData = _imageProps.propGetPointer(kOfxImagePropData);
+    _pixelData = _imageProps.propGetPointer(kOfxImagePropData, /*throwOnFailure*/!_OpenCLImage);
   }
 
   Image::~Image()

--- a/Support/include/ofxsImageEffect.h
+++ b/Support/include/ofxsImageEffect.h
@@ -434,13 +434,16 @@ namespace OFX {
     /** @brief If the slave  param changes the clip preferences need to be re-evaluated */
     void addClipPreferencesSlaveParam(ParamDescriptor &p);
 
-    /** @brief Does the plugin support OpenCL Render, defaults to false */
-    void setSupportsOpenCLRender(bool v);
+    /** @brief Does the plugin support OpenCL Buffers Render, defaults to false */
+    void setSupportsOpenCLBuffersRender(bool v);
+
+    /** @brief Does the plugin support OpenCL Images Render, defaults to false */
+    void setSupportsOpenCLImagesRender(bool v);
 
     /** @brief Does the plugin support CUDA Render, defaults to false */
     void setSupportsCudaRender(bool v);
 
-    /** @brief Does the plugin support CUDA Render, defaults to false */
+    /** @brief Does the plugin support CUDA Stream Render, defaults to false */
     void setSupportsCudaStream(bool v);
 
     /** @brief Does the plugin support Metal Render, defaults to false */
@@ -550,6 +553,7 @@ namespace OFX {
   class Image : public ImageBase {
   protected :
     void     *_pixelData;                    /**< @brief the base address of the image */
+    void     *_OpenCLImage;                  /**< @brief the OpenCL Image handle */
 
   public :
     /** @brief ctor */
@@ -563,6 +567,12 @@ namespace OFX {
 
     /** @brief get the pixel data for this image */
     const void *getPixelData(void) const { return _pixelData;}
+
+    /** @brief get the OpenCL Image for this image */
+    void *getOpenCLImage(void) { return _OpenCLImage;}
+
+    /** @brief get the OpenCL Image for this image */
+    const void *getOpenCLImage(void) const { return _OpenCLImage;}
 
     /** @brief return a pixel pointer, returns NULL if (x,y) is outside the image bounds
 

--- a/Support/include/ofxsProcessing.h
+++ b/Support/include/ofxsProcessing.h
@@ -145,9 +145,9 @@ namespace OFX {
         };
 
         /** @brief this is called by process to actually process images using CUDA when isEnabledCudaRender is true, override in derived classes */
-        virtual void processImagesCUDA(void)
+        virtual void processImagesCuda(void)
         {
-            OFX::Log::print("processImagesCUDA not implemented");
+            OFX::Log::print("processImagesCuda not implemented");
             OFX::throwSuiteStatusException(kOfxStatErrUnsupported);
         };
 
@@ -197,7 +197,7 @@ namespace OFX {
             else if (_isEnabledCudaRender)
             {
               OFX::Log::print("processing via CUDA");
-                processImagesCUDA();
+                processImagesCuda();
             }
             else if (_isEnabledMetalRender)
             {

--- a/include/ofxGPURender.h
+++ b/include/ofxGPURender.h
@@ -37,8 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	rendering of OpenFX Image Effect Plug-ins.  For details see
         \ref ofxGPURender.
 
-        It allows hosts and plugins to support OpenGL, CUDA, Metal and other
-        GPU acceleration methods.
+        It allows hosts and plug-ins to support OpenGL, OpenCL, CUDA, and Metal.
+        Additional GPU APIs, such a Vulkan, could use similar techniques.
 */
 
 #include "ofxImageEffect.h"
@@ -64,23 +64,23 @@ point) sample format */
   #define kOfxBitDepthHalf "OfxBitDepthHalf"
 #endif
 
-/** @brief Indicates whether a host or plugin can support OpenGL accelerated
+/** @brief Indicates whether a host or plug-in can support OpenGL accelerated
 rendering
 
    - Type - C string X 1
-   - Property Set - plugin descriptor (read/write), host descriptor (read
-only) - plugin instance change (read/write)
-   - Default - "false" for a plugin
+   - Property Set - plug-in descriptor (read/write), host descriptor (read
+only) - plug-in instance change (read/write)
+   - Default - "false" for a plug-in
    - Valid Values - This must be one of
-     - "false"  - in which case the host or plugin does not support OpenGL
+     - "false"  - in which case the host or plug-in does not support OpenGL
                   accelerated rendering
-     - "true"   - which means a host or plugin can support OpenGL accelerated
+     - "true"   - which means a host or plug-in can support OpenGL accelerated
                   rendering, in the case of plug-ins this also means that it
                   is capable of CPU based rendering in the absence of a GPU
-     - "needed" - only for plug-ins, this means that an effect has to have
+     - "needed" - only for plug-ins, this means that an plug-in has to have
                   OpenGL support, without which it cannot work.
 
-V1.4: It is now expected from host reporting v1.4 that the plugin can during instance change switch from true to false and false to true.
+V1.4: It is now expected from host reporting v1.4 that the plug-in can during instance change switch from true to false and false to true.
 
 */
 #define kOfxImageEffectPropOpenGLRenderSupported "OfxImageEffectPropOpenGLRenderSupported"
@@ -100,7 +100,7 @@ V1.4: It is now expected from host reporting v1.4 that the plugin can during ins
 
 
    - Type - string X N
-   - Property Set - plugin descriptor (read only)
+   - Property Set - plug-in descriptor (read only)
    - Default - none set
    - Valid Values - This must be one of
        - ::kOfxBitDepthNone (implying a clip is unconnected, not valid for an
@@ -113,13 +113,13 @@ V1.4: It is now expected from host reporting v1.4 that the plugin can during ins
 #define kOfxOpenGLPropPixelDepth "OfxOpenGLPropPixelDepth"
 
 
-/** @brief Indicates that an image effect SHOULD use OpenGL acceleration in
+/** @brief Indicates that a plug-in SHOULD use OpenGL acceleration in
 the current action
 
-   When a plugin and host have established they can both use OpenGL renders
-   then when this property has been set the host expects the plugin to render
+   When a plug-in and host have established they can both use OpenGL renders
+   then when this property has been set the host expects the plug-in to render
    its result into the buffer it has setup before calling the render.  The
-   plugin can then also safely use the 'OfxImageEffectOpenGLRenderSuite'
+   plug-in can then also safely use the 'OfxImageEffectOpenGLRenderSuite'
 
    - Type - int X 1
    - Property Set - inArgs property set of the following actions...
@@ -127,9 +127,9 @@ the current action
       - ::kOfxImageEffectActionBeginSequenceRender
       - ::kOfxImageEffectActionEndSequenceRender
    - Valid Values
-      - 0 indicates that the effect cannot use the OpenGL suite
-      - 1 indicates that the effect should render into the texture,
-        and may use the OpenGL suite functions.
+      - 0 indicates that the plug-in cannot use the OpenGL suite
+      - 1 indicates that the plug-in should render into the texture,
+          and may use the OpenGL suite functions.
 
 \note Once this property is set, the host and plug-in have agreed to
 use OpenGL, so the effect SHOULD access all its images through the
@@ -267,13 +267,13 @@ returns
                              in the handle,
   - ::kOfxStatFailed       - the image could not be fetched because it does
                              not exist in the clip at the indicated
-                             time and/or region, the plugin should continue
+                             time and/or region, the plug-in should continue
                              operation, but assume the image was black and
 			     transparent.
   - ::kOfxStatErrBadHandle - the clip handle was invalid,
   - ::kOfxStatErrMemory    - not enough OpenGL memory was available for the
                              effect to load the texture.
-                             The plugin should abort the GL render and
+                             The plug-in should abort the GL render and
 			     return ::kOfxStatErrMemory, after which the host can
 			     decide to retry the operation with CPU based processing.
 
@@ -315,14 +315,14 @@ clipLoadTexture
 
   /** @brief Request the host to minimize its GPU resource load
 
-  When a plugin fails to allocate GPU resources, it can call this function to
+  When a plug-in fails to allocate GPU resources, it can call this function to
   request the host to flush its GPU resources if it holds any.
-  After the function the plugin can try again to allocate resources which then
+  After the function the plug-in can try again to allocate resources which then
   might succeed if the host actually has released anything.
 
   \pre
   \post
-    - No changes to the plugin GL state should have been made.
+    - No changes to the plug-in GL state should have been made.
 
   @returns
     - ::kOfxStatOK           - the host has actually released some
@@ -337,18 +337,18 @@ resources,
 /** @brief Action called when an effect has just been attached to an OpenGL
 context.
 
-The purpose of this action is to allow a plugin to set up any data it may need
+The purpose of this action is to allow a plug-in to set up any data it may need
 to do OpenGL rendering in an instance. For example...
    - allocate a lookup table on a GPU,
-   - create an openCL or CUDA context that is bound to the host's OpenGL
+   - create an OpenCL or CUDA context that is bound to the host's OpenGL
      context so it can share buffers.
 
-The plugin will be responsible for deallocating any such shared resource in the
+The plug-in will be responsible for deallocating any such shared resource in the
 \ref ::kOfxActionOpenGLContextDetached action.
 
 A host cannot call ::kOfxActionOpenGLContextAttached on the same instance
 without an intervening ::kOfxActionOpenGLContextDetached. A host can have a
-plugin swap OpenGL contexts by issuing a attach/detach for the first context
+plug-in swap OpenGL contexts by issuing a attach/detach for the first context
 then another attach for the next context.
 
 The arguments to the action are...
@@ -357,23 +357,23 @@ The arguments to the action are...
   \arg inArgs - is redundant and set to null
   \arg outArgs - is redundant and set to null
 
-A plugin can return...
+A plug-in can return...
   - ::kOfxStatOK, the action was trapped and all was well
   - ::kOfxStatReplyDefault, the action was ignored, but all was well anyway
   - ::kOfxStatErrMemory, in which case this may be called again after a memory
     purge
   - ::kOfxStatFailed, something went wrong, but no error code appropriate,
-    the plugin should to post a message if possible and the host should not
-    attempt to run the plugin in OpenGL render mode.
+    the plug-in should to post a message if possible and the host should not
+    attempt to run the plug-in in OpenGL render mode.
 */
 #define kOfxActionOpenGLContextAttached "OfxActionOpenGLContextAttached"
 
 /** @brief Action called when an effect is about to be detached from an
 OpenGL context
 
-The purpose of this action is to allow a plugin to deallocate any resource
+The purpose of this action is to allow a plug-in to deallocate any resource
 allocated in \ref ::kOfxActionOpenGLContextAttached just before the host
-decouples a plugin from an OpenGL context.
+decouples a plug-in from an OpenGL context.
 The host must call this with the same OpenGL context active as it
 called with the corresponding ::kOfxActionOpenGLContextAttached.
 
@@ -383,14 +383,14 @@ The arguments to the action are...
   \arg inArgs - is redundant and set to null
   \arg outArgs - is redundant and set to null
 
-A plugin can return...
+A plug-in can return...
   - ::kOfxStatOK, the action was trapped and all was well
   - ::kOfxStatReplyDefault, the action was ignored, but all was well anyway
   - ::kOfxStatErrMemory, in which case this may be called again after a memory
     purge
   - ::kOfxStatFailed, something went wrong, but no error code appropriate,
-    the plugin should to post a message if possible and the host should not
-    attempt to run the plugin in OpenGL render mode.
+    the plug-in should to post a message if possible and the host should not
+    attempt to run the plug-in in OpenGL render mode.
 */
 #define kOfxActionOpenGLContextDetached "kOfxActionOpenGLContextDetached"
 
@@ -549,69 +549,75 @@ current for other OFX calls, such as ::kOfxImageEffectActionDescribeInContext.
  * @defgroup CudaRender CUDA Rendering
  * @{
  */
-/** @brief Indicates whether a host or plugin can support Cuda render
+/** @brief Indicates whether a host or plug-in can support CUDA render
 
     - Type - string X 1
-    - Property Set - plugin descriptor (read/write), host descriptor (read only)
-    - Default - "false"
+    - Property Set - plug-in descriptor (read/write), host descriptor (read only)
+    - Default - "false" for a plug-in
     - Valid Values - This must be one of
-      - "false"  - the host or plugin does not support Cuda render
-      - "true"   - the host or plugin can support Cuda render
+      - "false"  - the host or plug-in does not support CUDA render
+      - "true"   - the host or plug-in can support CUDA render
  */
 #define kOfxImageEffectPropCudaRenderSupported "OfxImageEffectPropCudaRenderSupported"
 
-/** @brief Indicates that an image effect SHOULD use Cuda render in
+/** @brief Indicates that a plug-in SHOULD use CUDA render in
 the current action
 
-   If a plugin and host have both set
+   If a plug-in and host have both set
    kOfxImageEffectPropCudaRenderSupported="true" then the host MAY set
-   this property to indicate that it is passing images as Cuda memory
+   this property to indicate that it is passing images as CUDA memory
    pointers.
 
    - Type - int X 1
-   - Property Set - inArgs property set of the kOfxImageEffectActionRender action
+   - Property Set - inArgs property set of the following actions...
+      - ::kOfxImageEffectActionRender
+      - ::kOfxImageEffectActionBeginSequenceRender
+      - ::kOfxImageEffectActionEndSequenceRender
    - Valid Values
       - 0 indicates that the kOfxImagePropData of each image of each clip
           is a CPU memory pointer.
       - 1 indicates that the kOfxImagePropData of each image of each clip
-	  is a Cuda memory pointer.
+	      is a CUDA memory pointer.
 */
 #define kOfxImageEffectPropCudaEnabled "OfxImageEffectPropCudaEnabled"
 
-/**  @brief Indicates whether a host or plugin can support Cuda streams
+/**  @brief Indicates whether a host or plug-in can support CUDA streams
 
     - Type - string X 1
-    - Property Set - plugin descriptor (read/write), host descriptor (read only)
-    - Default - "false"
+    - Property Set - plug-in descriptor (read/write), host descriptor (read only)
+    - Default - "false" for a plug-in
     - Valid Values - This must be one of
-      - "false"  - in which case the host or plugin does not support Cuda streams
-      - "true"   - which means a host or plugin can support Cuda streams
+      - "false"  - in which case the host or plug-in does not support CUDA streams
+      - "true"   - which means a host or plug-in can support CUDA streams
 
 */
 #define kOfxImageEffectPropCudaStreamSupported "OfxImageEffectPropCudaStreamSupported"
 
-/**  @brief The Cuda stream to be used for rendering
+/**  @brief The CUDA stream to be used for rendering
 
     - Type - pointer X 1
-    - Property Set - inArgs property set of the kOfxImageEffectActionRender action
+    - Property Set - inArgs property set of the following actions...
+       - ::kOfxImageEffectActionRender
+       - ::kOfxImageEffectActionBeginSequenceRender
+       - ::kOfxImageEffectActionEndSequenceRender
 
-This property will only be set if the host and plugin both support Cuda streams.
+This property will only be set if the host and plug-in both support CUDA streams.
 
 If set:
 
-- this property contains a pointer to the stream of Cuda render (cudaStream_t).
+- this property contains a pointer to the stream of CUDA render (cudaStream_t).
   In order to use it, reinterpret_cast<cudaStream_t>(pointer) is needed.
 
-- the plugin SHOULD ensure that its render action enqueues any
-  asynchronous Cuda operations onto the supplied queue.
+- the plug-in SHOULD ensure that its render action enqueues any
+  asynchronous CUDA operations onto the supplied queue.
 
-- the plugin SHOULD NOT wait for final asynchronous operations to
+- the plug-in SHOULD NOT wait for final asynchronous operations to
   complete before returning from the render action, and SHOULD NOT
   call cudaDeviceSynchronize() at any time.
 
 If not set:
 
-- the plugin SHOULD ensure that any asynchronous operations it
+- the plug-in SHOULD ensure that any asynchronous operations it
   enqueues have completed before returning from the render action.
 */
 #define kOfxImageEffectPropCudaStream "OfxImageEffectPropCudaStream"
@@ -622,48 +628,54 @@ If not set:
  * @defgroup MetalRender Apple Metal Rendering
  * @{
  */
-/** @brief Indicates whether a host or plugin can support Metal render
+/** @brief Indicates whether a host or plug-in can support Metal render
 
     - Type - string X 1
-    - Property Set - plugin descriptor (read/write), host descriptor (read only)
-    - Default - "false"
+    - Property Set - plug-in descriptor (read/write), host descriptor (read only)
+    - Default - "false" for a plug-in
     - Valid Values - This must be one of
-      - "false"  - the host or plugin does not support Metal render
-      - "true"   - the host or plugin can support Metal render
+      - "false"  - the host or plug-in does not support Metal render
+      - "true"   - the host or plug-in can support Metal render
  */
 #define kOfxImageEffectPropMetalRenderSupported "OfxImageEffectPropMetalRenderSupported"
 
-/** @brief Indicates that an image effect SHOULD use Metal render in
+/** @brief Indicates that a plug-in SHOULD use Metal render in
 the current action
 
-   If a plugin and host have both set
+   If a plug-in and host have both set
    kOfxImageEffectPropMetalRenderSupported="true" then the host MAY
    set this property to indicate that it is passing images as Metal
    buffers.
 
    - Type - int X 1
-   - Property Set - inArgs property set of the kOfxImageEffectActionRender action
+   - Property Set - inArgs property set of the following actions...
+      - ::kOfxImageEffectActionRender
+      - ::kOfxImageEffectActionBeginSequenceRender
+      - ::kOfxImageEffectActionEndSequenceRender
    - Valid Values
       - 0 indicates that the kOfxImagePropData of each image of each clip
           is a CPU memory pointer.
       - 1 indicates that the kOfxImagePropData of each image of each clip
-	  is a Metal id<MTLBuffer>.
+	      is a Metal id<MTLBuffer>.
 */
 #define kOfxImageEffectPropMetalEnabled "OfxImageEffectPropMetalEnabled"
 
 /**  @brief The command queue of Metal render
 
     - Type - pointer X 1
-    - Property Set - inArgs property set of the kOfxImageEffectActionRender action
+    - Property Set - inArgs property set of the following actions...
+       - ::kOfxImageEffectActionRender
+       - ::kOfxImageEffectActionBeginSequenceRender
+       - ::kOfxImageEffectActionEndSequenceRender
 
 This property contains a pointer to the command queue to be used for
 Metal rendering (id<MTLCommandQueue>). In order to use it,
 reinterpret_cast<id<MTLCommandQueue>>(pointer) is needed.
 
-The plugin SHOULD ensure that its render action enqueues any
+The plug-in SHOULD ensure that its render action enqueues any
 asynchronous Metal operations onto the supplied queue.
 
-The plugin SHOULD NOT wait for final asynchronous operations to
+The plug-in SHOULD NOT wait for final asynchronous operations to
 complete before returning from the render action.
 */
 #define kOfxImageEffectPropMetalCommandQueue "OfxImageEffectPropMetalCommandQueue"
@@ -673,52 +685,172 @@ complete before returning from the render action.
  * @defgroup OpenClRender OpenCL Rendering
  * @{
  */
-/** @brief Indicates whether a host or plugin can support OpenCL render
+/** @brief Indicates whether a host or plug-in can support OpenCL Buffers render
 
     - Type - string X 1
-    - Property Set - plugin descriptor (read/write), host descriptor (read only)
-    - Default - "false"
+    - Property Set - plug-in descriptor (read/write), host descriptor (read only)
+    - Default - "false" for a plug-in
     - Valid Values - This must be one of
-      - "false"  - the host or plugin does not support OpenCL render
-      - "true"   - the host or plugin can support OpenCL render
+      - "false"  - the host or plug-in does not support OpenCL Buffers render
+      - "true"   - the host or plug-in can support OpenCL Buffers render
  */
-
 #define kOfxImageEffectPropOpenCLRenderSupported "OfxImageEffectPropOpenCLRenderSupported"
 
-/** @brief Indicates that an image effect SHOULD use OpenCL render in
+ /** @brief Indicates whether a host or plug-in can support OpenCL Images render
+
+    - Type - string X 1
+    - Property Set - plug-in descriptor (read/write), host descriptor (read only)
+    - Default - "false" for a plug-in
+    - Valid Values - This must be one of
+      - "false"  - in which case the host or plug-in does not support OpenCL Images render
+      - "true"   - which means a host or plug-in can support OpenCL Images render
+ */
+#define kOfxImageEffectPropOpenCLSupported				"OfxImageEffectPropOpenCLSupported"
+
+ /** @brief Indicates that a plug-in SHOULD use OpenCL render in
 the current action
 
-   If a plugin and host have both set
-   kOfxImageEffectPropOpenCLRenderSupported="true" then the host MAY
+   If a plug-in and host have both set
+   kOfxImageEffectPropOpenCLRenderSupported="true" or have both 
+   set kOfxImageEffectPropOpenCLSupported="true" then the host MAY
    set this property to indicate that it is passing images as OpenCL
-   buffers.
+   Buffers or Images.
+
+   When rendering using OpenCL Buffers, the cl_mem of the buffers are retrieved using ::kOfxImagePropData.
+   When rendering using OpenCL Images, the cl_mem of the images are retrieved using ::kOfxImageEffectPropOpenCLImage.
+   If both ::kOfxImageEffectPropOpenCLSupported (Buffers) and ::kOfxImageEffectPropOpenCLRenderSupported (Images) are
+   enabled by the plug-in, it should use ::kOfxImageEffectPropOpenCLImage to determine which is being used by the host.
 
    - Type - int X 1
-   - Property Set - inArgs property set of the kOfxImageEffectActionRender action
+   - Property Set - inArgs property set of the following actions...
+      - ::kOfxImageEffectActionRender
+      - ::kOfxImageEffectActionBeginSequenceRender
+      - ::kOfxImageEffectActionEndSequenceRender
    - Valid Values
-      - 0 indicates that the kOfxImagePropData of each image of each clip
-          is a CPU memory pointer.
-      - 1 indicates that the kOfxImagePropData of each image of each clip
-	  is a cl_mem.
+      - 0 indicates that a plug-in SHOULD use OpenCL render in
+          the render action
+      - 1 indicates that a plug-in SHOULD NOT use OpenCL render in
+          the render action
 */
 #define kOfxImageEffectPropOpenCLEnabled "OfxImageEffectPropOpenCLEnabled"
 
-/**  @brief The command queue of OpenCL render
+/**  @brief Indicates the OpenCL command queue that should be used for rendering
 
     - Type - pointer X 1
-    - Property Set - inArgs property set of the kOfxImageEffectActionRender action
+    - Property Set - inArgs property set of the following actions...
+       - ::kOfxImageEffectActionRender
+       - ::kOfxImageEffectActionBeginSequenceRender
+       - ::kOfxImageEffectActionEndSequenceRender
 
 This property contains a pointer to the command queue to be used for
-Metal rendering (cl_command_queue). In order to use it,
+OpenCL rendering (cl_command_queue). In order to use it,
 reinterpret_cast<cl_command_queue>(pointer) is needed.
 
-The plugin SHOULD ensure that its render action enqueues any
+The plug-in SHOULD ensure that its render action enqueues any
 asynchronous OpenCL operations onto the supplied queue.
 
-The plugin SHOULD NOT wait for final asynchronous operations to
+The plug-in SHOULD NOT wait for final asynchronous operations to
 complete before returning from the render action.
 */
 #define kOfxImageEffectPropOpenCLCommandQueue "OfxImageEffectPropOpenCLCommandQueue"
+
+/** @brief Indicates the image handle of an image supplied as an OpenCL Image by the host
+
+- Type - pointer X 1
+- Property Set - image handle returned by clipGetImage
+
+This value should be cast to a cl_mem and used as the image handle when performing
+OpenCL Images operations. The property should be used (not ::kOfxImagePropData) when
+rendering with OpenCL Images (::kOfxImageEffectPropOpenCLSupported), and should be used
+to determine whether Images or Buffers should be used if a plug-in supports both
+::kOfxImageEffectPropOpenCLSupported and ::kOfxImageEffectPropOpenCLRenderSupported.
+Note: the kOfxImagePropRowBytes property is not required to be set by the host, since
+OpenCL Images do not have the concept of row bytes.
+*/
+#define kOfxImageEffectPropOpenCLImage					"OfxImageEffectPropOpenCLImage"
+
+
+#define kOfxOpenCLProgramSuite "OfxOpenCLProgramSuite"
+
+/** @brief OFX suite that allows a plug-in to get OpenCL programs compiled
+
+This is an optional suite the host can provide for building OpenCL programs for the plug-in,
+as an alternative to calling clCreateProgramWithSource / clBuildProgram. There are two advantages to
+doing this: The host can add flags (such as -cl-denorms-are-zero) to the build call, and may also
+cache program binaries for performance (however, if the source of the program or the OpenCL
+environment changes, the host must recompile so some mechanism such as hashing must be used).
+*/
+typedef struct OfxOpenCLProgramSuiteV1 {
+    /** @brief Compiles the OpenCL program */
+    OfxStatus(*compileProgram)(const char   *pszProgramSource,
+        int           fOptional,          // if non-zero, host may skip compiling on this call
+        void         *pResult);           // cast to cl_program*
+} OfxOpenCLProgramSuiteV1;
+
+
+/** @page ofxOpenCLRender OpenCL Acceleration of Rendering
+
+@section ofxOpenCLRenderIntro Introduction
+
+The OpenCL extension enables plug-ins to use OpenCL commands (typically backed by a GPU) to accelerate rendering of their outputs. The basic scheme is simple....
+- an plug-in indicates it wants to use OpenCL acceleration by setting the ::kOfxImageEffectPropOpenCLSupported (Images) and/or ::kOfxImageEffectPropOpenCLRenderSupported (Buffers) flags on it's descriptor.
+- a host indicates it supports OpenCL acceleration by setting ::kOfxImageEffectPropOpenCLSupported (Images) and/or ::kOfxImageEffectPropOpenCLRenderSupported (Buffers) on it's descriptor.
+- the host decides when to use OpenCL, and sets the ::kOfxImageEffectPropOpenCLEnabled property on the BeginRender/Render/EndRender calls to indicate this.
+- when OpenCL Images are being used (::kOfxImageEffectPropOpenCLSupported) the clip image property ::kOfxImageEffectPropOpenCLImage will be set and non-null.
+- when OpenCL Buffers are being used (::kOfxImageEffectPropOpenCLRenderSupported) the clip image property ::kOfxImagePropData will be set and non-null.
+
+@section ofxOpenCLRenderDiscoveryAndEnabling Discovery and Enabling
+
+If a host supports OpenCL rendering then it flags with the string property ::kOfxImageEffectPropOpenCLSupported (Images) and/or
+::kOfxImageEffectPropOpenCLRenderSupported (Buffers) on its descriptor property set. Effects that cannot run without OpenCL support
+should examine this in ::kOfxActionDescribe action and return a ::kOfxStatErrMissingHostFeature status flag if it is not set to "true".
+
+Effects flag to a host that they support OpenCL rendering by setting the string property ::kOfxImageEffectPropOpenCLSupported (Images)
+and/or ::kOfxImageEffectPropOpenCLRenderSupported (Buffers) on their effect descriptor during the ::kOfxActionDescribe action.
+Effects can work in two ways....
+- purely on CPUs without any OpenCL support at all, in which case they should set ::kOfxImageEffectPropOpenCLSupported (Images) and ::kOfxImageEffectPropOpenCLRenderSupported (Buffers) to be "false" (the default),
+- on CPUs but with optional OpenCL support, in which case they should set ::kOfxImageEffectPropOpenCLSupported (Images) and/or ::kOfxImageEffectPropOpenCLRenderSupported (Buffers) to be "true"
+
+Host may support just OpenCL Images, just OpenCL Buffers, or both, as indicated by which of these two properties they set "true".
+Likewise plug-ins may support just OpenCL Images, just OpenCL Buffers, or both, as indicated by which of these two properties they set "true".
+If both host and plug-in support both, it is up to the host which it uses. Typically, it will be based on what it uses natively (to avoid an extra copy operation).
+If a plug-in supports both, it must use ::kOfxImageEffectPropOpenCLImage to determine if Images or Buffers are being used for a given render action.
+
+Effects can use OpenCL render only during the following action:
+- ::kOfxImageEffectActionRender
+
+If a plug-in has indicated that it optionally supports OpenCL acceleration, it should check the property ::kOfxImageEffectPropOpenCLEnabled
+passed as an in argument to the following actions,
+- ::kOfxImageEffectActionRender
+- ::kOfxImageEffectActionBeginSequenceRender
+- ::kOfxImageEffectActionEndSequenceRender
+
+If this property is set to 0, then it must not attempt to use OpenCL while rendering.
+If this property is set to 1, then it must use OpenCL buffers or images while rendering.
+
+If a call using OpenCL rendering fails, the host may re-attempt using CPU buffers instead, but this is not required, and might not be efficient.
+
+@section ofxOpenCLRenderVersion OpenCL platform and device versions and feature support
+
+Assume an in-order command queue. Do not assume a profiling command queue.
+
+Effects should target OpenCL 1.1 API and OpenCL C kernel language support. Only minimum required features required
+in OpenCL 1.1 should be used (for example, see "5.3.2.1 Minimum List of Supported Image Formats" for the list
+of image types which can be expected to be supported across all devices). If you have specific requirements
+for features beyond these minimums, you will need to check the device (e.g., using clGetDeviceInfo with
+CL_DEVICE_EXTENSIONS) to see if your feature is available, and have a fallback if it's not.
+
+Temporary buffers and images should not be kept past the render action. A separate extension for host managed caching is in the works.
+
+Do not retain OpenCL objects without a matching release within the render action.
+
+@section ofxOpenCLRenderMultipleDevices Multiple OpenCL Devices
+
+This is very important: The host may support multiple OpenCL devices. Therefore the plug-in should keep a separate set of kernels per OpenCL content (e.g., using a map).
+The OpenCL context can be found from the command queue using clGetCommandQueueInfo with CL_QUEUE_CONTEXT.
+Failure to do this will cause crashes or incorrect results when the host switches to another OpenCL device.
+
+*/
 
 /** @}*/ // end OpenCLRender doc group
 

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -1244,7 +1244,7 @@ This contains the duration of the plug-in effect, in frames.
 
 This property contains one of:
   - a pointer to memory that is the lower left hand corner of an image
-  - a pointer to Cuda memory, if the Render action arguments includes kOfxImageEffectPropCudaEnabled=1
+  - a pointer to CUDA memory, if the Render action arguments includes kOfxImageEffectPropCudaEnabled=1
   - an id<MTLBuffer>, if the Render action arguments includes kOfxImageEffectPropMetalEnabled=1
   - a cl_mem, if the Render action arguments includes kOfxImageEffectPropOpenCLEnabled=1
 
@@ -1294,7 +1294,8 @@ For various alignment reasons, a row of pixels may need to be padded at the end 
 This property indicates the number of bytes in a row of pixels. This will be at least sizeof(PIXEL) * (bounds.x2-bounds.x1). Where bounds
 is fetched from the ::kOfxImagePropBounds property.
 
-Note that (for CPU images only, not Cuda/Metal/OpenCL buffers, nor textures accessed via the OpenGL Render Suite) row bytes can be negative, which allows hosts with a native top down row order to pass image into OFX without having to repack pixels.
+Note that (for CPU images only, not CUDA/Metal/OpenCL Buffers, nor OpenGL textures accessed via the OpenGL Render Suite) row bytes can be negative, which allows hosts with a native top down row order to pass image into OFX without having to repack pixels.
+Row bytes is not supported for OpenCL Images.
  */
 #define kOfxImagePropRowBytes "OfxImagePropRowBytes"
 


### PR DESCRIPTION
- Modify ofxGPURender.h to support OpenCL Images
- Add kOfxImageEffectActionBeginSequenceRender and kOfxImageEffectActionEndSequenceRender as required actions for some CUDA/Metal/OpenCL properties where they were not listed
- Also make documentation edits in the same header
- Modify GPUGain example to also support OpenCL Images and show how to disambiguate in the case where a plug-in supports both OpenCL Buffers and OpenCL Images