### PR TITLE
Remove symbol files as these are no longer needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ find_package(EXPAT)
 find_package(opengl_system)
 
 # Macros
-set(OFX_SUPPORT_SYMBOLS_DIR ${PROJECT_SOURCE_DIR}/symbols)
 include(OpenFX)
 set_property(GLOBAL PROPERTY OFX_PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}")
 

--- a/Examples/Makefile.master
+++ b/Examples/Makefile.master
@@ -35,7 +35,7 @@ $(OBJECTPATH)/%.o : %.cpp
 all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
 
   ifeq ($(OS),$(filter $(OS),MINGW64_NT-6.1 MINGW32_NT-6.1))
-    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/../symbols/linux.symbols -lopengl32
+    LINKFLAGS = -shared -fvisibility=hidden -lopengl32
     ARCH = Win32
     BITSFLAG = -m32
     ifeq ($(BITS), 64)
@@ -46,7 +46,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
   endif
   ifeq ($(OS),Linux)
     # use $ORIGIN to link to bundled libraries first, see http://itee.uq.edu.au/~daniel/using_origin/
-    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/../symbols/linux.symbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
+    LINKFLAGS = -shared -fvisibility=hidden -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
     ARCH = Linux-x86
     BITSFLAG = -m32 -fPIC
     ifeq ($(BITS), 64)
@@ -56,7 +56,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
     LINKFLAGS := $(LINKFLAGS) $(BITSFLAG)
   endif
   ifeq ($(OS),FreeBSD)
-    LINKFLAGS = -L/usr/local/lib -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/../symbols/linux.symbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
+    LINKFLAGS = -L/usr/local/lib -shared -fvisibility=hidden -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
     ARCH= FreeBSD-x86
     BITSFLAG = -m32 -fPIC
     ifeq ($(BITS), 64)
@@ -86,7 +86,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
       endif
       BITSFLAG = -isysroot /Developer/SDKs/MacOSX$(MACOSXSDK).sdk $(ARCHFLAGS) -mmacosx-version-min=$(MACOSX) -fPIC
     endif
-    LINKFLAGS = $(BITSFLAG) -bundle -fvisibility=hidden -exported_symbols_list $(PATHTOROOT)/../symbols/osx.symbols -framework OpenGL -Wl,-rpath,@loader_path/../Frameworks -Wl,-rpath,@loader_path/../Libraries
+    LINKFLAGS = $(BITSFLAG) -bundle -fvisibility=hidden -framework OpenGL -Wl,-rpath,@loader_path/../Frameworks -Wl,-rpath,@loader_path/../Libraries
     ARCH = MacOS
   endif
 

--- a/Support/Plugins/Makefile.master
+++ b/Support/Plugins/Makefile.master
@@ -46,7 +46,7 @@ SUPPORTOBJECTS = $(PATHTOROOT)/Library/$(OBJECTPATH)/ofxsMultiThread.o \
 all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
 
   ifeq ($(OS),$(filter $(OS),MINGW64_NT-6.1 MINGW32_NT-6.1))
-    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/include/linuxSymbols -lopengl32
+    LINKFLAGS = -shared -fvisibility=hidden -lopengl32
     ARCH = Win32
     BITSFLAG = -m32
     ifeq ($(BITS), 64)
@@ -57,7 +57,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
   endif
   ifeq ($(OS),Linux)
     # use $ORIGIN to link to bundled libraries first, see http://itee.uq.edu.au/~daniel/using_origin/
-    LINKFLAGS = -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/include/linuxSymbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
+    LINKFLAGS = -shared -fvisibility=hidden -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
     ARCH = Linux-x86
     BITSFLAG = -m32 -fPIC
     ifeq ($(BITS), 64)
@@ -67,7 +67,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
     LINKFLAGS := $(LINKFLAGS) $(BITSFLAG)
   endif
   ifeq ($(OS),FreeBSD)
-    LINKFLAGS = -L/usr/local/lib -shared -fvisibility=hidden -Xlinker --version-script=$(PATHTOROOT)/include/linuxSymbols -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
+    LINKFLAGS = -L/usr/local/lib -shared -fvisibility=hidden -lGL -Wl,-rpath,'$$ORIGIN'/../../Libraries
     ARCH= FreeBSD-x86
     BITSFLAG = -m32 -fPIC
     ifeq ($(BITS), 64)
@@ -104,7 +104,7 @@ all: $(OBJECTPATH)/$(PLUGINNAME).ofx.bundle
         BITSFLAG = $(ARCHFLAGS) -mmacosx-version-min=$(MACOSX) -fPIC
       endif
     endif
-    LINKFLAGS = $(BITSFLAG) -bundle -fvisibility=hidden -exported_symbols_list $(PATHTOROOT)/include/osxSymbols -framework OpenGL -Wl,-rpath,@loader_path/../Frameworks -Wl,-rpath,@loader_path/../Libraries
+    LINKFLAGS = $(BITSFLAG) -bundle -fvisibility=hidden -framework OpenGL -Wl,-rpath,@loader_path/../Frameworks -Wl,-rpath,@loader_path/../Libraries
     ARCH = MacOS
   endif
 

--- a/cmake/OpenFX.cmake
+++ b/cmake/OpenFX.cmake
@@ -28,31 +28,13 @@ function(add_ofx_plugin TARGET)
 	endif()
 	set_target_properties(${TARGET} PROPERTIES SUFFIX ".ofx" PREFIX "")
 
-	if(NOT DEFINED OFX_SUPPORT_SYMBOLS_DIR)
-		if (NOT DEFINED CONAN_OPENFX_ROOT)
-			message(FATAL_ERROR "Define OFX_SUPPORT_SYMBOLS_DIR to use add_ofx_plugin().")
-		endif()
-		set(OFX_SUPPORT_SYMBOLS_DIR ${CONAN_OPENFX_ROOT}/symbols)
-	endif()
+   # Set symbol visibility hidden. Individual symbols are exposed via
+   # __declspec(dllexport) or __attribute__((visibility("default")))
+   set_target_properties(${TARGET} PROPERTIES
+      C_VISIBILITY_PRESET hidden
+      CXX_VISIBILITY_PRESET hidden)
 
-	# Add extra flags to the link step of the plugin
-	if(APPLE)
-		set_target_properties(${TARGET} PROPERTIES
-                  LINK_FLAGS "-fvisibility=hidden -exported_symbols_list,${OFX_SUPPORT_SYMBOLS_DIR}/osx.symbols")
-	elseif(WIN32)
-		if (MSVC)
-			set_target_properties(${TARGET} PROPERTIES
-                    LINK_FLAGS "/def:${OFX_SUPPORT_SYMBOLS_DIR}/windows.symbols")
-    elseif(MINGW OR MSYS)
-      set_target_properties(${TARGET} PROPERTIES
-                    LINK_FLAGS "-Wl,-fvisibility=hidden,--version-script=${OFX_SUPPORT_SYMBOLS_DIR}/mingw.symbols")
-    endif()
-	else()
-		set_target_properties(${TARGET} PROPERTIES
-                  LINK_FLAGS "-Wl,-fvisibility=hidden,--version-script=${OFX_SUPPORT_SYMBOLS_DIR}/linux.symbols")
-	endif()
-
-        # To install plugins: cmake --install Build
-        install(TARGETS ${TARGET} DESTINATION "${PLUGINDIR}/${TARGET}.ofx.bundle/Contents/${ARCHDIR}")
-        install(FILES ${DIR}/Info.plist DESTINATION "${PLUGINDIR}/${TARGET}.ofx.bundle/Contents")
+   # To install plugins: cmake --install Build
+   install(TARGETS ${TARGET} DESTINATION "${PLUGINDIR}/${TARGET}.ofx.bundle/Contents/${ARCHDIR}")
+   install(FILES ${DIR}/Info.plist DESTINATION "${PLUGINDIR}/${TARGET}.ofx.bundle/Contents")
 endfunction()

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,6 @@ class openfx(ConanFile):
 		"include/*",
 		"scripts/*",
 		"Support/*",
-		"symbols/*",
 		"CMakeLists.txt",
 		"LICENSE",
 		"README.md",
@@ -67,13 +66,11 @@ class openfx(ConanFile):
 		copy(self,"*.ofx", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
 		copy(self,"*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
 		copy(self,"*.so", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
-		copy(self,"*.symbols", src=self.source_folder, dst=os.path.join(self.package_folder, "symbols"), keep_path=False)
 
 	def package_info(self):
 		libs = collect_libs(self)
 
 		self.cpp_info.set_property("cmake_build_modules", [os.path.join("cmake", "OpenFX.cmake")])
-		self.cpp_info.builddirs = ["symbols"]
 		self.cpp_info.components["Api"].includedirs = ["include"]
 		self.cpp_info.components["HostSupport"].libs = [i for i in libs if "OfxHost" in i]
 		self.cpp_info.components["HostSupport"].includedirs = ["HostSupport/include"]

--- a/symbols/linux.symbols
+++ b/symbols/linux.symbols
@@ -1,7 +1,0 @@
-OFX_1.0 {
-         global:
-		OfxGetNumberOfPlugins;
-		OfxGetPlugin;
-         local:
-                *;
-};

--- a/symbols/mingw.symbols
+++ b/symbols/mingw.symbols
@@ -1,7 +1,0 @@
-OFX_1.0 {
-         global:
-		OfxGetNumberOfPlugins;
-		OfxGetPlugin;
-         local:
-                *;
-};

--- a/symbols/osx.symbols
+++ b/symbols/osx.symbols
@@ -1,2 +1,0 @@
-_OfxGetPlugin
-_OfxGetNumberOfPlugins

--- a/symbols/windows.symbols
+++ b/symbols/windows.symbols
@@ -1,3 +1,0 @@
-EXPORTS
-	OfxGetPlugin
-	OfxGetNumberOfPlugins

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -41,7 +41,6 @@ class openfxTestConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["OFX_SUPPORT_SYMBOLS_DIR"] = os.path.join(self.dependencies["openfx"].package_folder,"symbols")
         tc.generate()
 
         # Create an environment script that defines the OFX_PLUGIN_PATH


### PR DESCRIPTION
Both the CMake and Makefile projects included compiler arguments to set symbol visibility to hidden and expose only the `OfxGetNumberOfPlugins` and `OfxGetPlugin` symbols. The CMake project has been changed to use built-in functionality to control symbol visibility, reducing the amount of platform-specific code that needs to be maintained.

Furthermore, all our examples use `__attribute__((visibility("default")))` to expose necessary symbols, rendering the symbol files unnecessary, so all references to the symbol files, and the files themselves have been removed.