### PR TITLE
Fix issues with Choice and StrChoice params, per #146

### DIFF
--- a/Documentation/sources/Reference/ofxParameter.rst
+++ b/Documentation/sources/Reference/ofxParameter.rst
@@ -191,6 +191,8 @@ with no compatibility impact, since the host should only store the
 index. But they should not change the *order* of options without using
 :c:macro:`kOfxParamPropChoiceOrder`.
 
+If no default value is set by the plugin, the host should use the first defined option (index 0).
+
 Setting Choice Param Order
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -286,7 +288,8 @@ for example
         gPropHost->propSetString(myChoiceParam, kOfxParamPropChoiceEnum, 2, "choice-3");
 
 The default value of a StrChoice param must be one of the specified
-enums, or the behavior is undefined.
+enums, or the behavior is undefined. If no default value is set by the plugin,
+the host should use the first defined option (index 0).
 
 It is an error to have gaps in the choices after the describe action
 has returned. The Option and Enum arrays must be of the same length,

--- a/Support/Plugins/ChoiceParams/choiceparams.cpp
+++ b/Support/Plugins/ChoiceParams/choiceparams.cpp
@@ -582,7 +582,7 @@ void ChoiceParamsExamplePluginFactory::describe(OFX::ImageEffectDescriptor& desc
 {
   // basic labels
   desc.setLabels("Choice Params (Support)", "ChoiceParams(spt)", "Choice Params (Support)");
-  desc.setPluginGrouping("OFX");
+  desc.setPluginGrouping("OFX Example (Support)");
 
   // add the supported contexts, only filter at the moment
   desc.addSupportedContext(eContextFilter);
@@ -642,6 +642,7 @@ void ChoiceParamsExamplePluginFactory::describeInContext(OFX::ImageEffectDescrip
   choice1->appendOption("red: none");
   choice1->appendOption("red: some");
   choice1->appendOption("red: lots");
+  choice1->setDefault(0);
   page->addChild(*choice1);
 
   // Note: index 1 is "lots" (even though UI order is 2), index 2 is "some"
@@ -650,6 +651,7 @@ void ChoiceParamsExamplePluginFactory::describeInContext(OFX::ImageEffectDescrip
   choice2->appendOption("green: none", "", 0);
   choice2->appendOption("green: lots", "", 2);
   choice2->appendOption("green: some", "", 1);
+  choice2->setDefault(0);
   page->addChild(*choice2);
 
   if (getImageEffectHostDescription()->supportsStrChoice)  {
@@ -657,6 +659,7 @@ void ChoiceParamsExamplePluginFactory::describeInContext(OFX::ImageEffectDescrip
     choice3->appendOption("blue_0.0", "blue: none", 0);
     choice3->appendOption("blue_0.5", "blue: some", 1);
     choice3->appendOption("blue_1.0", "blue: lots", 2);
+    choice3->setDefault("blue_0.0");
     page->addChild(*choice3);
   }
 }


### PR DESCRIPTION
* Set defaults for StrChoice params in examples
* Update doc to say that Choice and StrChoice params should use first defined option if the plugin doesn't specify a default
* Fix plugin grouping for Support/Plugins/ChoiceParams

See also PR #133.