### PR TITLE
Fix missing GPU include

### DIFF
--- a/Support/Library/ofxsImageEffect.cpp
+++ b/Support/Library/ofxsImageEffect.cpp
@@ -10,9 +10,7 @@
 #include <iostream>
 #endif
 #include <stdexcept>
-#ifdef OFX_SUPPORTS_OPENGLRENDER
 #include "ofxGPURender.h"
-#endif
 #include "ofxsCore.h"
 
 #if defined __APPLE__ || defined __linux__ || defined __FreeBSD__


### PR DESCRIPTION
Some variables like kOfxImageEffectPropOpenCLRenderSupported are used in ofxsImageEffect and are declared in ofxGPURender.h. So this file should always be included even if we build without OFX_SUPPORTS_OPENGLRENDER.