### PR TITLE
Rename colour management style defs

### DIFF
--- a/Examples/ColourSpace/colourspace.cpp
+++ b/Examples/ColourSpace/colourspace.cpp
@@ -402,7 +402,7 @@ getClipPreferences( OfxImageEffectHandle  effect,  OfxPropertySetHandle /*inArgs
   // Colour management -- preferred colour spaces, in order (most preferred first)
 #define PREFER_COLOURSPACES
 #ifdef PREFER_COLOURSPACES
-  if (gHostColourManagementStyle != kOfxImageEffectPropColourManagementNone) {
+  if (gHostColourManagementStyle != kOfxImageEffectColourManagementNone) {
     spdlog::info("Specifying preferred colourspaces since host style={}", gHostColourManagementStyle);
     if(!preferredInputSpace.empty()) {
       const char* colourSpaces[] = {
@@ -647,7 +647,7 @@ describe(OfxImageEffectHandle  effect)
     spdlog::info("describe: host says its colour management style is '{}'", gHostColourManagementStyle);
   } else {
     spdlog::info("describe: host does not support colour management (err={})", errMsg(stat));
-    gHostColourManagementStyle = kOfxImageEffectPropColourManagementNone;
+    gHostColourManagementStyle = kOfxImageEffectColourManagementNone;
   }
 
   // get the property handle for the plugin
@@ -674,13 +674,13 @@ describe(OfxImageEffectHandle  effect)
   gPropHost->propSetString(effectProps, kOfxImageEffectPropSupportedContexts, 0, kOfxImageEffectContextFilter);
   gPropHost->propSetString(effectProps, kOfxImageEffectPropSupportedContexts, 1, kOfxImageEffectContextGeneral);
 
-  if (gHostColourManagementStyle != kOfxImageEffectPropColourManagementNone) {
+  if (gHostColourManagementStyle != kOfxImageEffectColourManagementNone) {
     // host supports colour management, either OCIO or Core (or others; see the spec).
     // OCIO implies core, so here we can assume it supports Core.
     // Tell it we support Core.
     stat = gPropHost->propSetString(effectProps,
                                     kOfxImageEffectPropColourManagementStyle, 0,
-                                    kOfxImageEffectPropColourManagementCore);
+                                    kOfxImageEffectColourManagementCore);
     if (stat != kOfxStatOK) {
       spdlog::error("setting kOfxImageEffectPropColourManagementStyle prop: stat={}", errMsg(stat));
     }

--- a/include/ofxColour.h
+++ b/include/ofxColour.h
@@ -24,13 +24,13 @@ extern "C" {
 
    - Type - string X 1
    - Property Set - host descriptor (read only), plugin descriptor (read/write), image effect instance (read only)
-   - Default - kOfxImageEffectPropColourManagementStyleNone
+   - Default - kOfxImageEffectColourManagementStyleNone
    - Valid Values - This must be one of
-     - ::kOfxImageEffectPropColourManagementNone - no colour management
-     - ::kOfxImageEffectPropColourManagementBasic - only basic colourspaces from the config header may be used
-     - ::kOfxImageEffectPropColourManagementCore - only core colourspaces from the config header may be used
-     - ::kOfxImageEffectPropColourManagementFull - any colourspace from the config header may be used
-     - ::kOfxImageEffectPropColourManagementOCIO - any OCIO config may be used (implies use of the OCIO library)
+     - ::kOfxImageEffectColourManagementNone - no colour management
+     - ::kOfxImageEffectColourManagementBasic - only basic colourspaces from the config header may be used
+     - ::kOfxImageEffectColourManagementCore - only core colourspaces from the config header may be used
+     - ::kOfxImageEffectColourManagementFull - any colourspace from the config header may be used
+     - ::kOfxImageEffectColourManagementOCIO - any OCIO config may be used (implies use of the OCIO library)
 
 Hosts should set this property if they will provide colourspace information 
 to plug-ins.
@@ -58,15 +58,15 @@ effect instance.
 #define kOfxImageEffectPropColourManagementStyle "OfxImageEffectPropColourManagementStyle"
 
 /* String used to indicate that no colour management is available. */
-#define kOfxImageEffectPropColourManagementNone "OfxImageEffectPropColourManagementNone"
+#define kOfxImageEffectColourManagementNone "OfxImageEffectColourManagementNone"
 /* String used to indicate that basic colour management is available. */
-#define kOfxImageEffectPropColourManagementBasic "OfxImageEffectPropColourManagementBasic"
+#define kOfxImageEffectColourManagementBasic "OfxImageEffectColourManagementBasic"
 /* String used to indicate that core colour management is available. */
-#define kOfxImageEffectPropColourManagementCore "OfxImageEffectPropColourManagementCore"
+#define kOfxImageEffectColourManagementCore "OfxImageEffectColourManagementCore"
 /* String used to indicate that Full colour management is available. */
-#define kOfxImageEffectPropColourManagementFull "OfxImageEffectPropColourManagementFull"
+#define kOfxImageEffectColourManagementFull "OfxImageEffectColourManagementFull"
 /* String used to indicate that OCIO colour management is available. */
-#define kOfxImageEffectPropColourManagementOCIO "OfxImageEffectPropColourManagementOCIO"
+#define kOfxImageEffectColourManagementOCIO "OfxImageEffectColourManagementOCIO"
 
 /** @brief What native mode configs are supported?
 
@@ -102,7 +102,7 @@ set this even in OCIO mode, to define the basic colourspaces.
    - Valid Values - Filesystem path to the config or URI starting ocio://
 
 A host must set this property on any effect instances where it has negotiated 
-OCIO colour management (kOfxImageEffectPropColourManagementOCIO).
+OCIO colour management (kOfxImageEffectColourManagementOCIO).
 Use of URIs for built-in configs, such as ocio://default is permitted.
 */
 #define kOfxImageEffectPropOCIOConfig "OfxImageEffectPropOCIOConfig"


### PR DESCRIPTION
The colour management style definitions contained the string ‘Prop’ which was incorrect because they aren’t properties. This complicated the introspection project so has been corrected. Fixes #168. 