### PR TITLE
Fix doxygen reference for OfxTimeLineSuiteV1

### DIFF
--- a/Documentation/sources/Reference/suites/ofxTimeLineSuiteReference.rst
+++ b/Documentation/sources/Reference/suites/ofxTimeLineSuiteReference.rst
@@ -3,6 +3,4 @@
 OfxTimeLineSuiteV1
 ==================
 
-.. doxygenstruct:: OfxImageEffectSuiteV1
-
-
+.. doxygenstruct:: OfxTimeLineSuiteV1


### PR DESCRIPTION
The documentation page for `OfxTimeLineSuiteV1` was incorrectly referencing `OfxImageEffectSuiteV1` instead.