### PR TITLE
Doc fixes: clipGetRegionOfDefinition, Interacts

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -2,16 +2,27 @@
 
 This is the documentation directory for OFX, the open visual effects standard.
 
-# Building Docs
+## Documentation Architecture
+
+The OpenFX documentation system combines several tools:
+
+1. **Doxygen** - Parses C/C++ header files in the `include` directory to extract API documentation from comments
+2. **Breathe** - A Sphinx extension that bridges Doxygen XML output with Sphinx
+3. **Sphinx** - Processes ReStructured Text (.rst) files and Doxygen output to generate the final HTML documentation
+4. **Python scripts** - Custom scripts like `genPropertiesReference.py` extract property definitions from source files
+
+The documentation is organized into:
+- **Reference manual** - API documentation generated from Doxygen comments in the header files
+- **Guide** - Tutorial content with examples in ReStructured Text
+- **Release notes** - Version-specific information
+
+## Building Docs
 
 Buildthedocs.io will auto-build whenever changes are pushed to master.
 But to build the docs yourself, e.g. to check that your updates look
 right, you can do your own doc build.
 
-Right now building the docs is somewhat manual. The below assumes
-Linux, but Mac is similar.
-
-## Prerequisites
+### Prerequisites
 
 * Install doxygen (Linux: `sudo apt install doxygen`)
 * Create a python3 virtualenv: `python -mvenv ofx-docgen` (may need to do `apt install python3.8-venv` first)
@@ -21,47 +32,143 @@ Linux, but Mac is similar.
 (Virtualenv is recommended, but not required; you could install the reqs into your
 system python if you like.)
 
-## Build:
+### Build Process
 
-* Make sure your virtualenv above is activated: `source ofx-docgen/bin/activate`
-* Generate references:
-  `python Documentation/genPropertiesReference.py -i include -o Documentation/sources/Reference/ofxPropertiesReference.rst -r`
-* Build the doxygen docs: `cd include; doxygen ofx.doxy; cd -` (you'll see
-  some warnings)
-* Build the sphinx docs:
-  `cd Documentation; sphinx-build -b html sources build`
-* Note that you can do all the above using the build script in `Documentation/build.sh`.
-* Now open
-  file:///path/to/your/ofx/openfx/Documentation/build/index.html in
-  your browser; your changes should be there.
+The simplest way to build the documentation is to run the build script:
 
-# Doxygen notes:
+```bash
+cd Documentation
+./build.sh
+```
 
-Doxygen is used in the source and headers. The doc build process
-parses the doxygen comments to build docs, then breathe to merge them
-with the `.rst` sphinx docs. See the [Doxygen docs](https://www.doxygen.nl/manual/docblocks.html)
+This script performs the following steps:
 
-* Params/Actions/etc. should be added to groups using `\defgroup`, `\ingroup` and `\addtogroup`. Use `@{` / `@}` to add multiple items.
-* Use `\ref` to refer to entities in doxygen.
+1. Generates property references using `genPropertiesReference.py`
+2. Builds Doxygen documentation from the header files
+3. Uses Breathe to collect Doxygen API docs
+4. Builds the final HTML documentation with Sphinx
 
+After building, you can view the documentation at:
+`file:///path/to/your/ofx/openfx/Documentation/build/index.html`
 
-# RST Notes:
+If you want to run the steps manually, you can follow the steps in `build.sh`.
 
-RST (ReStructured Text) is used for the prose documentation in the `/Documentation` subtree, using Sphinx and Breathe.
+## Documentation Writing Guide
 
-* Internal links:
-  - Define: `.. _target-name:` (must be *globally unique*!)
-  - Reference: ``:ref:`target-name` ``
-  - Good to put these just before section headers; the link will refer to the header in that case.
-  - See [Sphinx Docs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref)
-  - Links to structs/etc.:
-    - ``:ref:`OfxHost<OfxHost>` ``
-  - Links to documents:
-    - ``:doc:`docname` `` (if docname starts with `/` it's absolute, otherwise rel to current file)
-  - C macros: `` :c:macro:`kOfxParamPropChoiceOrder` `` (struct/var/func/member/enum/type/... work too), 
-    see the [Doc](https://www.sphinx-doc.org/en/master/usage/domains/c.html#c-roles)
-  - You can also reference `#define`s using this syntax: ``.. doxygendefine:: kOfxImageEffectRenderUnsafe`` on its own line,
-    which pulls in the whole doxygen block for that `#define`.
-* Useful macros:
-  - `` .. literalinclude:: README.txt ``
+### Doxygen Documentation
 
+Doxygen is used to document C/C++ code in the source and headers. The main Doxygen configuration is in `include/ofx.doxy`.
+
+#### Key Doxygen Features Used in OpenFX
+
+* **Groups** - Organize related items together
+  ```c
+  /** \defgroup PropertiesAll Property Suite */
+  /** \ingroup PropertiesAll */
+  /** \addtogroup PropertiesAll @{ ... @} */
+  ```
+
+* **Documentation Comments** - Document functions, structs, defines, etc.
+  ```c
+  /**
+   * \brief Brief description
+   * 
+   * Detailed description that can span
+   * multiple lines
+   * 
+   * \param paramName Description of parameter
+   * \return Description of return value
+   */
+  ```
+
+* **Cross-references** - Link to other documentation elements
+  ```c
+  /** See \ref kOfxImageEffectPropSupportedPixelDepths */
+  ```
+
+### ReStructured Text (RST) Documentation
+
+RST files are used for the prose documentation in the `/Documentation/sources` directory.
+
+#### Key RST Features Used in OpenFX
+
+* **Section Headers** - Create hierarchy with underlines
+  ```rst
+  Section Title
+  ============
+  
+  Subsection Title
+  ---------------
+  ```
+
+* **Internal Links** - Create references between sections
+  ```rst
+  .. _target-name:
+  
+  Section Title
+  ============
+  
+  See :ref:`target-name` for more information.
+  ```
+
+* **Code Blocks** - Display code examples
+  ```rst
+  .. code-block:: c
+     
+     #define kOfxImageEffectPluginRenderThreadSafety "OfxImageEffectPluginRenderThreadSafety"
+  ```
+
+* **Including Files** - Embed external file content
+  ```rst
+  .. literalinclude:: ../examples/basic.cpp
+     :language: cpp
+     :lines: 10-20
+  ```
+
+* **Doxygen Integration** - Include Doxygen-documented items
+  ```rst
+  .. doxygendefine:: kOfxImageEffectPropSupportsMultiResolution
+  
+  .. doxygenfunction:: OfxGetPropertySet
+  
+  .. doxygenstruct:: OfxRectD
+     :members:
+  ```
+
+* **Cross-domain References** - Link to C/C++ elements
+  ```rst
+  :c:macro:`kOfxImageEffectPropSupportsOverlays`
+  :cpp:class:`OfxImageEffectStruct`
+  :c:struct:`OfxRectD`
+  :c:func:`OfxGetPropertySet`
+  ```
+
+### Breathe Integration
+
+The Breathe extension bridges Doxygen and Sphinx, enabling:
+
+* Automatic generation of API documentation pages
+* Full cross-referencing between RST and Doxygen content
+* Consistent styling across all documentation
+
+## Documentation Maintenance Tips
+
+1. **Common Issues**
+   - Missing cross-references - Check spelling of target names
+   - Doxygen parse errors - Check comment formatting
+   - Breathe integration issues - Check Doxygen XML output
+
+2. **Adding New Documentation**
+   - For new API elements: Add Doxygen comments to header files
+   - For new concepts/guides: Create new RST files in `sources/Guide`
+   - For property references: They're automatically generated from headers
+
+3. **Property Documentation**
+   - Property definitions are extracted automatically by `genPropertiesReference.py`
+   - Format should be: `#define kOfxPropName "OfxPropName"`
+   - Add Doxygen comments above property definitions
+
+4. **Testing Changes**
+   - Always build documentation locally before submitting changes
+   - Check for warning messages during the build process
+   - Review the HTML output to ensure proper formatting and cross-references

--- a/Documentation/sources/Guide/ofxExample5_Circle.rst
+++ b/Documentation/sources/Guide/ofxExample5_Circle.rst
@@ -364,7 +364,7 @@ What is this region of definition action? Easy, an effect and a clip
 have a region of definition (RoD). This is the maximum rectangle for
 which an effect or clip can produce pixels. You can ask for RoD of a
 clip via the :cpp:func:`OfxImageEffectSuiteV1::clipGetRegionOfDefinition` function in the image
-effect suite. The RoD is currently defined in canonical coordinates [4]_.
+effect suite. The RoD is defined in canonical coordinates [4]_.
 
 Note that the RoD is independent of the **bounds** of a image, an
 image’s bounds may be less than, more than or equal to the RoD. It is up

--- a/Documentation/sources/Guide/ofxExample5_Circle.rst
+++ b/Documentation/sources/Guide/ofxExample5_Circle.rst
@@ -360,11 +360,12 @@ where we set the **gHostSupportsMultiRes** global variable.
 Get Region Of Definition Action
 ===============================
 
-What is this region of definition action? Easy, an effect and a clip
-have a region of definition (RoD). This is the maximum rectangle for
-which an effect or clip can produce pixels. You can ask for RoD of a
-clip via the :cpp:func:`OfxImageEffectSuiteV1::clipGetRegionOfDefinition` function in the image
-effect suite. The RoD is defined in canonical coordinates [4]_.
+An effect and a clip each have a region of definition (RoD). This is
+the maximum rectangle for which an effect or clip can produce pixels.
+You can ask for the RoD of a clip via the
+:cpp:func:`OfxImageEffectSuiteV1::clipGetRegionOfDefinition` function
+in the image effect suite. The RoD is defined in canonical coordinates
+[4]_.
 
 Note that the RoD is independent of the **bounds** of a image, an
 image’s bounds may be less than, more than or equal to the RoD. It is up
@@ -378,9 +379,9 @@ drawing. Whether we do that or not is controlled by the "growRoD"
 parameter which is conditionally defined in the describe in context
 action.
 
-To set the output rod, we need to trap the
-:c:macro:`kOfxImageEffectActionGetRegionOfDefinition` action. Our MainEntry
-function now has an extra conditional in there….
+To set the plugin's output RoD, the plugin must to handle the
+:c:macro:`kOfxImageEffectActionGetRegionOfDefinition` action. The
+MainEntry function now has an extra conditional in there….
 
 `circle.cpp <https://github.com/AcademySoftwareFoundation/openfx/blob/doc/Documentation/sources/Guide/Code/Example5/circle.cpp#L978>`__
 

--- a/Documentation/sources/Reference/ofxPropertiesReference.rst
+++ b/Documentation/sources/Reference/ofxPropertiesReference.rst
@@ -47,17 +47,7 @@ Properties Reference
 
 .. doxygendefine:: kOfxImageEffectPropColourManagementAvailableConfigs
 
-.. doxygendefine:: kOfxImageEffectColourManagementBasic
-
-.. doxygendefine:: kOfxImageEffectColourManagementConfig
-
-.. doxygendefine:: kOfxImageEffectColourManagementCore
-
-.. doxygendefine:: kOfxImageEffectColourManagementFull
-
-.. doxygendefine:: kOfxImageEffectColourManagementNone
-
-.. doxygendefine:: kOfxImageEffectColourManagementOCIO
+.. doxygendefine:: kOfxImageEffectPropColourManagementConfig
 
 .. doxygendefine:: kOfxImageEffectPropColourManagementStyle
 

--- a/include/ofxDrawSuite.h
+++ b/include/ofxDrawSuite.h
@@ -80,7 +80,7 @@ typedef enum OfxDrawTextAlignment
 } OfxDrawTextAlignment;
 
 /** @brief OFX suite that allows an effect to draw to a host-defined display context.
-
+    To use this, the plugin must use kOfxImageEffectPluginPropOverlayInteractV2.
 */
 typedef struct OfxDrawSuiteV1 {
 	/** @brief Retrieves the host's desired draw colour for

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -106,7 +106,7 @@ These are the list of actions passed to an image effect plugin's main function. 
  definition see \ref ImageEffectArchitectures "Image Effect Architectures"
 
  Note that hosts that have constant sized imagery need not call this
- action, only hosts that allow image sizes to vary need call this.
+ action. Only hosts that allow image sizes to vary need call this.
 
  @param  handle handle to the instance, cast to an \ref OfxImageEffectHandle
 
@@ -116,12 +116,12 @@ These are the list of actions passed to an image effect plugin's main function. 
      - \ref kOfxImageEffectPropRenderScale the render scale that should be used in any calculations in this
      action
 
- @param  outArgs has the following property which the plug-in may set
+ @param  outArgs has the following property which the plug-in may set:
      - \ref kOfxImageEffectPropRegionOfDefinition  the calculated region of definition, initially set by the host
      to the default RoD (see below), in Canonical Coordinates.
 
 
- If the effect did not trap this, it means the host should use the
+ If the effect does not handle this action, the host should use the
  default RoD instead, which depends on the context. This is...
 
  -  generator context - defaults to the project window,
@@ -154,15 +154,13 @@ These are the list of actions passed to an image effect plugin's main function. 
  way, depending on the host architecture, a host can fetch the minimal
  amount of the image needed as input. Note that there is a region of
  interest to be set in ``outArgs`` for each input clip that exists on the
- effect. For more details see \ref ImageEffectArchitectures "Image Effect
- Architectures"
-
+ effect. For more details see
+ \ref ImageEffectArchitectures "Image Effect Architectures"
 
  The default RoI is simply the value passed in on the
  \ref kOfxImageEffectPropRegionOfInterest
- ``inArgs`` property set. All the RoIs in the ``outArgs`` property set
- must initialised to this value before the action is called.
-
+ ``inArgs`` property set. The host must initalize all the RoIs in the ``outArgs`` property set
+ to this value before the action is called.
 
  @param  handle handle to the instance, cast to an \ref OfxImageEffectHandle
  @param  inArgs has the following properties
@@ -171,7 +169,7 @@ These are the list of actions passed to an image effect plugin's main function. 
      - \ref kOfxImageEffectPropRegionOfInterest the region to be rendered in the output image, in Canonical Coordinates.
 
  @param  outArgs has a set of 4 dimensional double properties, one for each of the input clips to the effect.
- The properties are each named ``OfxImageClipPropRoI_`` with the clip name post pended, for example
+ The properties are each named ``OfxImageClipPropRoI_`` with the clip name postpended, for example
  ``OfxImageClipPropRoI_Source``. These are initialised to the default RoI.
 
 
@@ -188,8 +186,9 @@ These are the list of actions passed to an image effect plugin's main function. 
 
 /** @brief
  This action allows a host to ask an effect what range of frames it can
- produce images over. Only effects instantiated in the \ref generalContext "General
- Context" can have this called on them. In all other
+ produce images over. Only effects instantiated in the
+ \ref generalContext "General Context"
+ can have this called on them. In all other
  the host is in strict control over the temporal duration of the effect.
 
  The default is:

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -1582,18 +1582,11 @@ If clipGetImage is called twice with the same parameters, then two separate imag
  */
   OfxStatus (*clipReleaseImage)(OfxPropertySetHandle imageHandle);
   
-
   /** @brief Returns the spatial region of definition of the clip at the given time
 
-      \arg \c clipHandle  clip to extract the image from
-      \arg \c time        time to fetch the image at
-      \arg \c region      region to fetch the image from (optional, set to NULL to get a 'default' region)
-                            this is in the \ref CanonicalCoordinates. 
-      \arg \c imageHandle handle where the image is returned
-
-  An image is fetched from a clip at the indicated time for the given region and returned in the imageHandle.
-
- If the \e region parameter is not set to NULL, then it will be clipped to the clip's Region of Definition for the given time. The returned image will be \em at \em least as big as this region. If the region parameter is not set, then the region fetched will be at least the Region of Interest the effect has previously specified, clipped the clip's Region of Definition.
+      \arg \c clipHandle  return this clip's region of definition
+      \arg \c time        time to use when determining clip's region of definition
+      \arg \c bounds      (out) bounds are returned here -- in \ref CanonicalCoordinates
 
 \pre
  - clipHandle was returned by clipGetHandle
@@ -1602,13 +1595,10 @@ If clipGetImage is called twice with the same parameters, then two separate imag
  - bounds will be filled the RoD of the clip at the indicated time
 
 @returns
-- ::kOfxStatOK - the image was successfully fetched and returned in the handle,
-- ::kOfxStatFailed - the image could not be fetched because it does not exist in the clip at the indicated time, the plugin
-                     should continue operation, but assume the image was black and transparent.
+- ::kOfxStatOK - the region was successfully found and returned in the handle,
+- ::kOfxStatFailed - the region could not be determined,
 - ::kOfxStatErrBadHandle - the clip handle was invalid,
 - ::kOfxStatErrMemory - the host had not enough memory to complete the operation, plugin should abort whatever it was doing.
-
-
   */
   OfxStatus (*clipGetRegionOfDefinition)(OfxImageClipHandle clip,
 					 OfxTime time,

--- a/include/ofxInteract.h
+++ b/include/ofxInteract.h
@@ -229,7 +229,9 @@ These are the list of actions passed to an interact's entry point function. For 
  This action is issued to an interact whenever the host needs the plugin
  to redraw the given interact.
 
- The interact should either issue OpenGL calls to draw itself, or use DrawSuite calls.
+ The interact should either issue OpenGL calls (if the plugin is using
+ OverlayInteractV1) to draw itself, or use DrawSuite calls (if using
+ OverlayInteractV2).
 
  If this is called via kOfxImageEffectPluginPropOverlayInteractV2, drawing MUST use DrawSuite.
  


### PR DESCRIPTION
Add more info about the interaction between DrawSuite and Overlay
Interacts, for clarity.

Also clean up some doc around RegionOfInterest.

Also update the Documentation README to include a lot more useful
info.