### PR TITLE
Add `OfxImageEffectPropNoSpatialAwareness`

### DIFF
--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -1175,15 +1175,16 @@ Also note that some hosts do implement kOfxImageEffectPropRenderScale - these tw
 #define kOfxImageEffectPropRenderQualityDraft "OfxImageEffectPropRenderQualityDraft"
 
 /** @brief Indicates that the plugin can render without spatial awareness, either inherently or by
-disabling certain parameters at render time. If the plugin descriptor has this prop set to "true", the 
-plugin is expected to disable spatial effects when the host sets this prop to "true" in the render call arguments.
+disabling certain parameters at render time. 
+
+If the plugin descriptor has this property set to "true", the plugin is expected to disable spatial effects when the host sets this property to "true" in the arguments passed to kOfxImageEffectActionBeginSequenceRender and kOfxImageEffectActionRender.
 
     - Type - string X 1
     - Property Set - plugin descriptor (read/write), render calls - host (read-only)
     - Default - "false"
     - Valid Values - This must be one of
-      - "false"  - the plugin cannot render without spatial awareness and the host will bypass it for renders that require no spatial awareness. 
-      - "true"   - the plugin can render without spatial awareness, and the host will indicate this type of render by setting kOfxImageEffectPropNoSpatialAwareness to "true" in the render call.
+      - "false"  - the plugin cannot render without spatial awareness and the host should bypass it for renders that require no spatial awareness.
+      - "true"   - the plugin can render without spatial awareness. The host will indicate this type of render by setting kOfxImageEffectPropNoSpatialAwareness to "true" in the arguments passed to kOfxImageEffectActionBeginSequenceRender and kOfxImageEffectActionRender.
  */
 #define kOfxImageEffectPropNoSpatialAwareness "OfxImageEffectPropNoSpatialAwareness"
 

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -407,6 +407,7 @@ These are the list of actions passed to an image effect plugin's main function. 
      -  \ref kOfxImageEffectPropSequentialRenderStatus whether the effect is currently being rendered in strict frame order on a single instance
      -  \ref kOfxImageEffectPropInteractiveRenderStatus if the render is in response to a user modifying the effect in an interactive session
      -  \ref kOfxImageEffectPropRenderQualityDraft if the render should be done in draft mode (e.g. for faster scrubbing)
+     -  \ref kOfxImageEffectPropNoSpatialAwareness if the plugin must render without spatial awareness (e.g. for LUT generation)
 
  @param  outArgs is redundant and should be set to NULL
 
@@ -1172,6 +1173,19 @@ If an host does not support that property a value of 0 is assumed.
 Also note that some hosts do implement kOfxImageEffectPropRenderScale - these two properties can be used independently. 
  */
 #define kOfxImageEffectPropRenderQualityDraft "OfxImageEffectPropRenderQualityDraft"
+
+/** @brief Indicates that the plugin can render without spatial awareness, either inherently or by
+disabling certain parameters at render time. If the plugin descriptor has this prop set to "true", the 
+plugin is expected to disable spatial effects when the host sets this prop to "true" in the render call arguments.
+
+    - Type - string X 1
+    - Property Set - plugin descriptor (read/write), render calls - host (read-only)
+    - Default - "false"
+    - Valid Values - This must be one of
+      - "false"  - the plugin cannot render without spatial awareness and the host will bypass it for renders that require no spatial awareness. 
+      - "true"   - the plugin can render without spatial awareness, and the host will indicate this type of render by setting kOfxImageEffectPropNoSpatialAwareness to "true" in the render call.
+ */
+#define kOfxImageEffectPropNoSpatialAwareness "OfxImageEffectPropNoSpatialAwareness"
 
 /** @brief The extent of the current project in canonical coordinates.
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -23,6 +23,7 @@ This is version 1.6 of the OpenFX API.
 
 ## Detailed List of Changes
 
+- Add `kOfxImageEffectPropNoSpatialAwareness`. Allows the host and plugin to coordinate a render that ensures no spatial changes to the image.
 
 # Release Notes - 1.5
 


### PR DESCRIPTION
Plugins should be able to opt-in to host's LUT generators (or other non-spatial renders), and hosts need a way of indicating to the plugin that the current render requires rendering without spatial awareness. 

Resolve has already defined an extension `OfxImageEffectPropNoSpatialAwareness`, so I propose using that for both the plugin descriptor and the read-only render argument passed by the host.

Closes #127