### PR TITLE
Fix spec and host support lib to return proper val for host type

### DIFF
--- a/Documentation/sources/Reference/ofxPropertiesByObject.rst
+++ b/Documentation/sources/Reference/ofxPropertiesByObject.rst
@@ -15,11 +15,11 @@ Properties on the Image Effect Host
 -  kOfxPropAPIVersion
    - (read only) the version of the API implemented by the host. If not present, it is safe to assume "1.0"
 -  kOfxPropType
-   - (read only) set to "host"
+   - (read only) type of the object. Set to kOfxTypeImageEffectHost
 -  kOfxPropName
    - (read only) the globally unique name of the application, eg: "com.acmesofware.funkyCompositor"
 -  kOfxPropLabel
-   - (read only) the user visible name of the appliaction,
+   - (read only) the user visible name of the application
 -  kOfxPropVersion
    - (read only) the version number of the host
 -  kOfxPropVersionLabel

--- a/HostSupport/src/ofxhHost.cpp
+++ b/HostSupport/src/ofxhHost.cpp
@@ -56,7 +56,7 @@ namespace OFX {
 
     static const Property::PropSpec hostStuffs[] = {
       { kOfxPropAPIVersion, Property::eInt, 0, false, "" },
-      { kOfxPropType, Property::eString, 1, false, "Host" },
+      { kOfxPropType, Property::eString, 1, false, kOfxTypeImageEffectHost },
       { kOfxPropName, Property::eString, 1, false, "UNKNOWN" },
       { kOfxPropLabel, Property::eString, 1, false, "UNKNOWN" },
       { kOfxPropVersion, Property::eInt, 0, false, "0" },

--- a/release-notes.md
+++ b/release-notes.md
@@ -19,6 +19,9 @@ This is version 1.6 of the OpenFX API.
 
 ## Fixes in OpenFX Version 1.6:
 
+- Clarify that Image Effect Hosts property `kOfxPropType` must have the value
+  `kOfxTypeImageEffectHost`, and fix host support lib to implement that.
+
 ## Deprecations
 
 ## Detailed List of Changes


### PR DESCRIPTION
Image Effect Host objects must have `OfxPropType` with value "OfxTypeImageEffectHost" (== `kOfxTypeImageEffectHost`).

The host support lib was incorrectly returning the string "Host" here. Fixes #186.